### PR TITLE
Set up Vite bundling and module entrypoints

### DIFF
--- a/ensure-dist.js
+++ b/ensure-dist.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+const { existsSync, statSync, readdirSync } = require('fs');
+const { join } = require('path');
+const { spawnSync } = require('child_process');
+
+const root = __dirname;
+const distIndex = join(root, 'dist', 'index.html');
+
+const importantFiles = [
+  'index.html',
+  'settings.html',
+  'vite.config.js',
+  'package.json'
+];
+const importantDirs = ['src'];
+
+function newestMtime(dir) {
+  let latest = 0;
+  const entries = readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+    const full = join(dir, entry.name);
+    const stats = statSync(full);
+    if (entry.isDirectory()) {
+      latest = Math.max(latest, newestMtime(full));
+    } else {
+      latest = Math.max(latest, stats.mtimeMs);
+    }
+  }
+  return latest;
+}
+
+function shouldRebuild() {
+  if (process.env.FORCE_VITE_BUILD === '1') {
+    return true;
+  }
+  if (!existsSync(distIndex)) {
+    return true;
+  }
+  const distTime = statSync(distIndex).mtimeMs;
+  for (const file of importantFiles) {
+    const full = join(root, file);
+    if (existsSync(full) && statSync(full).mtimeMs > distTime) {
+      return true;
+    }
+  }
+  for (const dir of importantDirs) {
+    const full = join(root, dir);
+    if (existsSync(full) && newestMtime(full) > distTime) {
+      return true;
+    }
+  }
+  return false;
+}
+
+if (shouldRebuild()) {
+  console.log('[ensure-dist] Building renderer with `npm run build:frontend`...');
+  const result = spawnSync('npm', ['run', 'build:frontend'], {
+    stdio: 'inherit',
+    shell: process.platform === 'win32'
+  });
+  if (result.status !== 0) {
+    console.error('[ensure-dist] Failed to build renderer.');
+    process.exit(result.status ?? 1);
+  }
+} else {
+  console.log('[ensure-dist] Using existing dist assets.');
+}

--- a/index.html
+++ b/index.html
@@ -11,53 +11,74 @@
   <script type="module" src="/src/pages/dashboard.js"></script>
 </head>
 <body>
-  <div class="blob1 blob"></div>
-<div class="blob2 blob"></div>
-<div class="blob3 blob"></div>
-<div class="blob blob4"></div>
+  <div class="app-background" aria-hidden="true">
+    <div class="blob blob1"></div>
+    <div class="blob blob2"></div>
+    <div class="blob blob3"></div>
+  </div>
+
+  <header id="appChrome" class="app-chrome" role="banner">
+    <div class="app-chrome__title">
+      <span class="app-chrome__logo" aria-hidden="true">⌂</span>
+      <div class="app-chrome__text">
+        <span class="app-chrome__label">Hubitat</span>
+        <span class="app-chrome__subtitle">Bedroom Dashboard</span>
+      </div>
+    </div>
+    <div class="app-chrome__actions">
+      <button class="chrome-btn" id="settingsBtn" type="button" aria-label="Open settings">
+        <svg class="chrome-btn__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path d="M19.14 12.94a7.07 7.07 0 0 0 .05-.94 7.07 7.07 0 0 0-.05-.94l2.11-1.65a.5.5 0 0 0 .12-.62l-2-3.46a.5.5 0 0 0-.6-.22l-2.49 1a6.78 6.78 0 0 0-1.63-.94L14.5 3h-5l-.18 2.17a6.78 6.78 0 0 0-1.63.94l-2.49-1a.5.5 0 0 0-.6.22l-2 3.46a.5.5 0 0 0 .12.62l2.11 1.65a7.07 7.07 0 0 0 0 1.88L2.72 13.6a.5.5 0 0 0-.12.62l2 3.46a.5.5 0 0 0 .6.22l2.49-1a6.78 6.78 0 0 0 1.63.94L9.5 21h5l.18-2.17a6.78 6.78 0 0 0 1.63-.94l2.49 1a.5.5 0 0 0 .6-.22l2-3.46a.5.5 0 0 0-.12-.62ZM12 15.5A3.5 3.5 0 1 1 15.5 12 3.5 3.5 0 0 1 12 15.5Z" fill="currentColor" />
+        </svg>
+        <span>Settings</span>
+      </button>
+    </div>
+  </header>
+  <div id="appChromeHotspot" class="app-chrome__hotspot" aria-hidden="true"></div>
 
   <div id="lockIndicator" class="lock-indicator" aria-live="polite" aria-label="Front door lock" title="Front door lock">🔓</div>
-  <!-- Modern Clock -->
-  <div class="clock">
+
+  <div class="clock" aria-hidden="true">
     <div class="date" id="currentDate"></div>
     <div class="time" id="currentTime"></div>
   </div>
-  <div id="side-carousel-container" class="side-carousel-container">
-    <div id="side-carosel"></div>
-  </div>
-  <div class="switch-card">
-    <div class="wall-plate-wrap">
-      <div class="paddle-labels">
-        <span class="paddle-label">Lights</span>
-        <span class="paddle-label">All</span>
-      </div>
-      <div class="wall-plate">
-      <div class="paddle-switch off" id="paddleSwitch">
-        <span class="power-icon">⏻</span>
-      </div>
-      <div class="paddle-switch off" id="paddleSwitch2">
-        <span class="power-icon">⏻</span>
-      </div>
-      </div>
-    </div>
-      
-      
-    <div class="side-btns side-btns-visible" id="sideBtns">
-      <button class="side-btn" title="TV" aria-label="TV" data-action="showTvModal">📺</button>
-      <button class="side-btn" title="Lights" aria-label="Lights" data-action="showBubbleChartModal">💡</button>
-      <button class="side-btn rollershadeSideBtn" title="Rollershade" aria-label="Rollershade" data-action="showRollershadeModal">🪟</button>
-      <button class="side-btn" title="Lock" aria-label="Lock" data-action="toggleLock">🔒</button>
-      <button class="side-btn" title="Camera" aria-label="Camera" data-action="showCameraModal">📷</button>
-      <button class="side-btn" title="Thermostat" aria-label="Thermostat" data-action="showThermostatModal">🌡️</button>
-      <button class="side-btn" title="Music" aria-label="Music" data-action="showMusicModal">🎵</button>
-      <button class="side-btn" id="settingsBtn" title="Settings" aria-label="Settings">⚙️</button>
-      <!-- Theme toggle button -->
-      <button class="side-btn" id="themeToggle" title="Toggle Theme" aria-label="Toggle Theme">🌙</button>
-    </div>
-  </div>
 
-  <!-- Simple Modal -->
+  <main class="dashboard" role="main">
+    <section class="primary-stack">
+      <div class="switch-card">
+        <div class="wall-plate-wrap">
+          <div class="paddle-labels">
+            <span class="paddle-label">Lights</span>
+            <span class="paddle-label">All</span>
+          </div>
+          <div class="wall-plate">
+            <div class="paddle-switch off" id="paddleSwitch">
+              <span class="power-icon">⏻</span>
+            </div>
+            <div class="paddle-switch off" id="paddleSwitch2">
+              <span class="power-icon">⏻</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
 
+    <aside class="quick-panel" aria-label="Quick actions">
+      <div id="side-carousel-container" class="side-carousel-container">
+        <div id="side-carosel"></div>
+      </div>
+      <div class="side-btns side-btns-visible" id="sideBtns">
+        <button class="side-btn" title="TV" aria-label="TV" data-action="showTvModal">📺</button>
+        <button class="side-btn" title="Lights" aria-label="Lights" data-action="showBubbleChartModal">💡</button>
+        <button class="side-btn rollershadeSideBtn" title="Rollershade" aria-label="Rollershade" data-action="showRollershadeModal">🪟</button>
+        <button class="side-btn" title="Lock" aria-label="Lock" data-action="toggleLock">🔒</button>
+        <button class="side-btn" title="Camera" aria-label="Camera" data-action="showCameraModal">📷</button>
+        <button class="side-btn" title="Thermostat" aria-label="Thermostat" data-action="showThermostatModal">🌡️</button>
+        <button class="side-btn" title="Music" aria-label="Music" data-action="showMusicModal">🎵</button>
+        <button class="side-btn" id="themeToggle" title="Toggle Theme" aria-label="Toggle Theme">🌙</button>
+      </div>
+    </aside>
+  </main>
 
   <div class="modal-bg" id="modalBg">
     <div class="modal bubble" id="modalContent">

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "main.js",
   "scripts": {
     "dev": "vite",
-    "start": "npm run build:frontend && electron .",
+    "start": "node ensure-dist.js && electron .",
     "build": "npm run build:frontend && electron-builder",
     "build:frontend": "vite build",
     "preview": "vite preview",

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -4,35 +4,145 @@
 
 /* CSS Custom Properties for common values */
 :root {
-  --common-gradient: linear-gradient(145deg, rgba(255,255,255,0.08), rgba(0,0,0,0.25)), #232526;
-  --common-gradient-dark: linear-gradient(145deg, rgba(255,255,255,0.12), rgba(0,0,0,0.35)), #1a1a1a;
-  
+  color-scheme: dark;
+
+  --app-bg: radial-gradient(circle at 16% 20%, #1f2943 0%, #10172a 44%, #050a18 100%);
+  --app-bg-low-power: linear-gradient(160deg, #111a2e 0%, #050a16 100%);
+  --surface: rgba(17, 23, 36, 0.82);
+  --surface-strong: rgba(16, 22, 36, 0.92);
+  --surface-muted: rgba(17, 29, 54, 0.55);
+  --surface-border: rgba(148, 177, 255, 0.15);
+  --surface-border-strong: rgba(184, 209, 255, 0.35);
+  --text-primary: #f4f7ff;
+  --text-muted: rgba(214, 224, 255, 0.72);
+  --accent: #7dd3fc;
+  --accent-strong: #38bdf8;
+  --accent-soft: rgba(125, 211, 252, 0.18);
+  --shadow-soft: 0 22px 45px rgba(6, 10, 22, 0.55);
+  --shadow-strong: 0 32px 64px rgba(4, 8, 18, 0.58);
+  --radius-lg: 28px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+  --transition-base: 200ms cubic-bezier(0.4, 0, 0.2, 1);
+  --chrome-height: clamp(54px, 7vh, 74px);
+  --quick-button-size: clamp(64px, 6vw, 82px);
+
   /* Carousel slider variables */
-  --b: 60; --s: 70; --h: 30; --k: 3500;
-  --bg: #7a7a7a; --pill: #4b4b4b; --warm: #ffb163; --cool: #bcd6ff; --cream: #fff0cf; --text: #fff;
+  --b: 60;
+  --s: 70;
+  --h: 30;
+  --k: 3500;
+  --bg: #7a7a7a;
+  --pill: #4b4b4b;
+  --warm: #ffb163;
+  --cool: #bcd6ff;
+  --cream: #fff0cf;
+  --text: #fff;
   --roller-shade-img: none;
 }
 
 /* Base body styles */
 body {
   margin: 0;
-  height: 100vh;
+  min-height: 100vh;
   overflow: hidden;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-family: system-ui, "Noto Color Emoji", 'Segoe UI', Arial, sans-serif;
-  -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  -khtml-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
+  position: relative;
+  display: grid;
+  place-items: center;
+  padding: clamp(32px, 8vh, 72px) clamp(24px, 6vw, 64px);
+  font-family: 'Inter', 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-variant-numeric: tabular-nums;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  background: var(--app-bg);
+  color: var(--text-primary);
   user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
   -webkit-tap-highlight-color: transparent;
   touch-action: manipulation;
-  position: relative;
-  background: linear-gradient(135deg, rgb(10, 10, 30), rgb(35, 35, 60));
-  color: rgba(255, 229, 176, 1);
+}
+
+body.low-power {
+  background: var(--app-bg-low-power);
+}
+
+.app-background {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  z-index: -2;
+  pointer-events: none;
+}
+
+.blob {
+  position: absolute;
+  width: 52vmax;
+  height: 52vmax;
+  border-radius: 50%;
+  filter: blur(120px);
+  opacity: 0.45;
+  mix-blend-mode: screen;
+  animation: drift 62s ease-in-out infinite alternate;
+  will-change: transform, opacity;
+}
+
+.blob1 {
+  top: 12%;
+  left: 18%;
+  background: radial-gradient(circle at 40% 40%, rgba(132, 165, 255, 0.85) 0%, transparent 65%);
+}
+
+.blob2 {
+  top: 68%;
+  left: 30%;
+  background: radial-gradient(circle at 30% 60%, rgba(249, 168, 212, 0.75) 0%, transparent 70%);
+  animation-duration: 74s;
+}
+
+.blob3 {
+  top: 42%;
+  left: 82%;
+  background: radial-gradient(circle at 60% 40%, rgba(94, 234, 212, 0.78) 0%, transparent 68%);
+  animation-duration: 66s;
+}
+
+.blob4 {
+  display: none;
+}
+
+@keyframes drift {
+  0% {
+    transform: translate3d(-4%, -2%, 0) scale(0.96);
+    opacity: 0.4;
+  }
+  25% {
+    transform: translate3d(6%, -4%, 0) scale(1.08);
+    opacity: 0.55;
+  }
+  50% {
+    transform: translate3d(-8%, 6%, 0) scale(0.88);
+    opacity: 0.45;
+  }
+  75% {
+    transform: translate3d(10%, 8%, 0) scale(1.12);
+    opacity: 0.6;
+  }
+  100% {
+    transform: translate3d(-4%, -2%, 0) scale(0.96);
+    opacity: 0.42;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .blob {
+    animation: none;
+    opacity: 0.25;
+  }
+}
+
+body.low-power .blob {
+  display: none;
 }
   
 /* ========================================
@@ -101,6 +211,159 @@ body {
    UI COMPONENTS
    ======================================== */
 
+.app-chrome {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--chrome-height);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: clamp(16px, 4vw, 48px);
+  padding: 0 clamp(24px, 5vw, 56px);
+  background: linear-gradient(180deg, rgba(4, 9, 21, 0.85) 0%, rgba(4, 9, 21, 0.55) 100%);
+  border-bottom: 1px solid var(--surface-border);
+  backdrop-filter: blur(16px);
+  transform: translateY(-120%);
+  opacity: 0;
+  pointer-events: none;
+  transition: transform var(--transition-base), opacity var(--transition-base);
+  z-index: 1200;
+}
+
+.app-chrome.visible {
+  transform: translateY(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.app-chrome__title {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.app-chrome__logo {
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  background: rgba(125, 211, 252, 0.12);
+  border: 1px solid rgba(125, 211, 252, 0.32);
+  color: var(--accent);
+  font-size: 1.3rem;
+}
+
+.app-chrome__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.app-chrome__label {
+  font-size: 0.72rem;
+  opacity: 0.7;
+  letter-spacing: 0.16em;
+}
+
+.app-chrome__subtitle {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.app-chrome__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.app-chrome__hotspot {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 18px;
+  z-index: 1100;
+}
+
+@media (pointer: coarse) {
+  .app-chrome__hotspot {
+    height: 28px;
+  }
+}
+
+.chrome-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid transparent;
+  border-radius: 18px;
+  padding: 10px 18px;
+  background: rgba(125, 211, 252, 0.14);
+  color: var(--text-primary);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: background var(--transition-base), border-color var(--transition-base), transform var(--transition-base);
+}
+
+.chrome-btn svg {
+  width: 22px;
+  height: 22px;
+}
+
+.chrome-btn:hover,
+.chrome-btn:focus-visible {
+  border-color: rgba(125, 211, 252, 0.45);
+  background: rgba(56, 189, 248, 0.22);
+  transform: translateY(-1px);
+}
+
+.chrome-btn:focus-visible {
+  outline: 3px solid rgba(125, 211, 252, 0.35);
+  outline-offset: 3px;
+}
+
+.dashboard {
+  position: relative;
+  width: min(1120px, 92vw);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 0.78fr);
+  gap: clamp(32px, 6vw, 64px);
+  align-items: stretch;
+  z-index: 20;
+}
+
+.primary-stack {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.quick-panel {
+  display: grid;
+  gap: clamp(24px, 4vh, 36px);
+  align-content: start;
+}
+
+@media (max-width: 1100px) {
+  .dashboard {
+    grid-template-columns: 1fr;
+    width: min(960px, 94vw);
+  }
+
+  .quick-panel {
+    order: -1;
+  }
+}
+
 /* Emoji replacement styles */
 .icon.emoji-replaced,
 .power-icon.emoji-replaced,
@@ -117,45 +380,59 @@ body {
 /* Lock indicator */
 .lock-indicator {
   position: fixed;
-  top: 12px;
-  right: 12px;
-  width: 28px;
-  height: 28px;
+  top: calc(var(--chrome-height) + 28px);
+  right: clamp(24px, 5vw, 56px);
+  width: 56px;
+  height: 56px;
   display: grid;
   place-items: center;
-  font-size: 18px;
-  border-radius: 8px;
-  background: rgba(0,0,0,0.08);
-  color: #222;
-  z-index: 1100;
+  font-size: 1.45rem;
+  border-radius: 18px;
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  color: var(--text-primary);
+  z-index: 1000;
   pointer-events: none;
-  box-shadow: 0 1px 4px rgba(0,0,0,0.12);
+  box-shadow: 0 16px 34px rgba(8, 12, 24, 0.5);
+  backdrop-filter: blur(12px);
 }
-.lock-indicator.locked { background: rgba(46, 204, 113, 0.2); }
-.lock-indicator.unlocked { background: rgba(231, 76, 60, 0.2); }
+
+.lock-indicator.locked {
+  border-color: rgba(56, 189, 248, 0.45);
+  background: rgba(56, 189, 248, 0.16);
+}
+
+.lock-indicator.unlocked {
+  border-color: rgba(248, 113, 113, 0.4);
+  background: rgba(248, 113, 113, 0.16);
+}
 
 /* Clock display */
 .clock {
   position: fixed;
-  top: 60px !important;
-  left: 60px;
-  color:rgba(255, 229, 176, 1);
-  font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif !important;
-  z-index: 1000;
-  text-align: left;
+  top: calc(var(--chrome-height) + 36px);
+  left: clamp(24px, 6vw, 64px);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
   pointer-events: none;
-  }
+  z-index: 950;
+  color: var(--text-primary);
+  text-shadow: 0 18px 38px rgba(0, 0, 0, 0.4);
+}
+
 .clock .date {
-  font-size: 2.5em;
-  font-weight: 200;
-  margin-bottom: 2px;
-  opacity: 1;
+  font-size: clamp(1.1rem, 3vw, 1.6rem);
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
 }
 
 .clock .time {
-  font-size: 4em;
-  font-weight: 220;
-  letter-spacing: 1px;
+  font-size: clamp(2.4rem, 6vw, 3.6rem);
+  font-weight: 600;
+  letter-spacing: 0.04em;
 }
 
 /* ========================================
@@ -163,101 +440,136 @@ body {
    ======================================== */
 
 .switch-card {
+  position: relative;
   display: flex;
-  flex-direction: row;
   align-items: center;
   justify-content: center;
-  width: 320px;
-  height: 320px;
-  background: none;
-  position: relative;
-  z-index: 2;
+  padding: clamp(24px, 4vw, 38px);
+  background: var(--surface-strong);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-strong);
+  min-width: min(420px, 70vw);
+  min-height: clamp(360px, 38vw, 460px);
+  backdrop-filter: blur(16px);
 }
 
 .wall-plate-wrap {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 10px;
+  gap: clamp(20px, 3vw, 28px);
 }
+
 
 .paddle-labels {
   display: flex;
+  align-items: center;
   justify-content: space-between;
-  width: 350px;
-  padding: 0 20px;
+  width: min(360px, 65vw);
+  color: var(--text-muted);
+  text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: 0.08em;
 }
 
 .paddle-label {
-    color: rgba(255, 229, 176, 1);
-    font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    font-weight: 200;
-    font-size: 2.4em;
-    letter-spacing: 0.5px;
-    margin-left: -10px;
-    margin-right: -10px;
-    padding: 0px 0px 25px 0px;
+  font-family: inherit;
+  font-size: clamp(1rem, 3vw, 1.3rem);
+  font-weight: 600;
+  color: var(--text-muted);
 }
 .wall-plate {
-  width: 350px;
-  height: 425px;
-  background: #f5f5f5;
-  border-radius: 18px;
-  box-shadow: 0 2px 12px #bbb, 0 0 0 4px #e0e0e0;
-  display: flex; 
-  align-items: center; 
+  width: min(360px, 64vw);
+  height: min(460px, 78vw);
+  background: linear-gradient(160deg, rgba(246, 248, 255, 0.14), rgba(20, 28, 46, 0.65));
+  border-radius: 26px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.25),
+    inset 0 -16px 32px rgba(10, 15, 26, 0.4),
+    0 22px 40px rgba(6, 12, 22, 0.5);
+  display: flex;
+  align-items: center;
   justify-content: space-between;
   position: relative;
-  padding: 0 20px;
+  padding: 0 clamp(18px, 2.6vw, 28px);
 }
 
 .paddle-switch {
-  width: 35%;
-  height: 48%;
-  background: #e0e0e0;
-  border-radius: 10px;
-  box-shadow: 0 2px 8px #aaa inset, 0 2px 8px #fff;
+  width: 36%;
+  height: 52%;
+  background: linear-gradient(180deg, rgba(241, 245, 255, 0.92), rgba(214, 219, 237, 0.88));
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  box-shadow:
+    inset 0 6px 12px rgba(255, 255, 255, 0.45),
+    inset 0 -14px 18px rgba(14, 19, 33, 0.15),
+    0 12px 18px rgba(10, 14, 28, 0.26);
   position: relative;
-  transition: background 0.2s, box-shadow 0.2s, transform 0.3s cubic-bezier(.4,2,.6,1);
+  transition: transform 240ms cubic-bezier(.34, 1.4, .55, 1), box-shadow var(--transition-base), background var(--transition-base);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 2em;
-  color: #888;
+  font-size: 2.2rem;
+  color: rgba(28, 35, 57, 0.75);
   user-select: none;
 }
 
+.paddle-switch::before {
+  content: '';
+  position: absolute;
+  inset: 10% 18%;
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgba(235, 241, 255, 0.95), rgba(185, 195, 224, 0.35));
+  transition: opacity var(--transition-base);
+}
+
+.paddle-switch .power-icon {
+  position: relative;
+  z-index: 1;
+}
+
 .paddle-switch.on {
-  background: #ffd600;
-  color: #222;
-  box-shadow: 0 4px 16px rgba(255,214,0,0.5) inset, 0 2px 8px #fff;
-  transform: translateY(-60px);
+  background: linear-gradient(180deg, rgba(255, 225, 97, 0.92), rgba(255, 176, 37, 0.92));
+  color: rgba(46, 32, 2, 0.85);
+  box-shadow:
+    inset 0 8px 16px rgba(255, 255, 255, 0.55),
+    inset 0 -12px 18px rgba(186, 75, 6, 0.2),
+    0 16px 20px rgba(12, 18, 32, 0.42);
+  transform: translateY(-58px);
 }
 
 .paddle-switch.off {
-  transform: translateY(60px);
+  transform: translateY(58px);
+  box-shadow:
+    inset 0 6px 12px rgba(255, 255, 255, 0.35),
+    inset 0 -14px 18px rgba(14, 19, 33, 0.15),
+    0 10px 14px rgba(10, 14, 28, 0.22);
 }
 
+
 .side-btns {
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-  margin-left: 24px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(var(--quick-button-size), 1fr));
+  gap: clamp(12px, 2vw, 20px);
+  padding: clamp(18px, 3vh, 26px);
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(16px);
   opacity: 0;
   pointer-events: none;
-  transition: opacity 1s;
+  transform: translateY(16px);
+  transition: opacity var(--transition-base), transform var(--transition-base);
 }
 
 .side-btns-visible {
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-  margin-left: 24px;
   opacity: 1 !important;
   pointer-events: auto;
-  transition: opacity 0.4s;
-  transition-delay: 0.3s;
+  transform: translateY(0);
 }
 .rollershadeSideBtn {
   background-image: var(--roller-shade-img, none);
@@ -272,32 +584,72 @@ body {
 
 /* Improve side button aesthetics */
 .side-btn {
-  background: rgba(0,0,0,0.15);
-  background-size: 50%;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.08), rgba(11, 18, 33, 0.82));
+  background-size: 52%;
   background-position: center;
   background-repeat: no-repeat;
-  border: none;
-  border-radius: 50%;
-  width: 82px;
-  height: 82px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 22px;
+  width: 100%;
+  aspect-ratio: 1;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: #222;
-  backdrop-filter: blur(4px);
-  box-shadow: 0 2px 10px rgba(0,0,0,0.15);
-  font-size: 1.5em;
-  transition: box-shadow 180ms ease, outline-color 180ms ease, filter 160ms ease, transform 120ms ease;
-  will-change: box-shadow, filter, transform;
+  color: var(--text-primary);
+  box-shadow: 0 14px 24px rgba(6, 10, 22, 0.4);
+  font-size: clamp(1.6rem, 5vw, 2.1rem);
+  transition: transform var(--transition-base), box-shadow var(--transition-base), border-color var(--transition-base);
+  position: relative;
+  overflow: hidden;
 }
 
-.dark-theme .side-btn {
-  background: rgba(255,255,255,0.08);
-  color: #fff;
+.side-btn::after {
+  content: '';
+  position: absolute;
+  inset: 12% 14%;
+  border-radius: 18px;
+  background: radial-gradient(circle at 30% 20%, rgba(255, 255, 255, 0.18), transparent 65%);
+  opacity: 0;
+  transition: opacity var(--transition-base);
 }
 
-.side-btn:hover {
-  transform: scale(1.1) translate(-50%,-50%);
+.side-btn:hover,
+.side-btn:focus-visible {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 28px rgba(8, 12, 24, 0.48);
+  border-color: rgba(125, 211, 252, 0.4);
+}
+
+.side-btn:hover::after,
+.side-btn:focus-visible::after {
+  opacity: 1;
+}
+
+.side-btn:focus-visible {
+  outline: 3px solid rgba(125, 211, 252, 0.3);
+  outline-offset: 3px;
+}
+
+.side-btn:active {
+  transform: scale(0.96);
+}
+
+body.low-power .switch-card {
+  box-shadow: 0 18px 36px rgba(4, 8, 18, 0.45);
+}
+
+body.low-power .side-btns {
+  box-shadow: 0 14px 26px rgba(5, 9, 20, 0.4);
+  backdrop-filter: blur(8px);
+}
+
+body.low-power .side-btn {
+  transition-duration: 160ms;
+  box-shadow: 0 10px 20px rgba(6, 10, 22, 0.32);
+}
+
+body.low-power .side-btn::after {
+  display: none;
 }
 
 /* ========================================
@@ -323,24 +675,25 @@ body {
 }
 
 .modal {
-  background: linear-gradient(145deg, #2a2a2a, #1a1a1a);
-  border-radius: 50%;
-  padding: 40px;
-  width: 480px;
-  height: 480px;
-  max-width: 90vw;
-  max-height: 90vh;
+  background: var(--surface-strong);
+  border-radius: 36px;
+  padding: clamp(28px, 4vw, 40px);
+  width: clamp(320px, 62vw, 560px);
+  height: clamp(320px, 62vw, 560px);
+  max-width: 92vw;
+  max-height: 92vh;
   overflow-y: auto;
   position: relative;
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(255, 255, 255, 0.1);
-  transform: scale(0.7);
+  box-shadow: var(--shadow-strong);
+  border: 1px solid var(--surface-border);
+  transform: scale(0.86);
   opacity: 0;
-  transition: all 0.3s ease;
+  transition: transform var(--transition-base), opacity var(--transition-base);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  color: #fff;
+  color: var(--text-primary);
 }
 
 .modal.bubble {
@@ -708,175 +1061,116 @@ body {
    RESPONSIVE DESIGN
    ======================================== */
 
-@media (max-width: 600px) {
-  
-  .btn {
-    padding: 12px 20px;
-    font-size: 0.9em;
-    min-height: 44px;
+@media (max-width: 720px) {
+  body {
+    padding: 24px 18px;
   }
-  
-  .side-btn {
-    width: 56px;
-    height: 56px;
-    font-size: 1.5em;
+
+  .dashboard {
+    width: min(720px, 100%);
+    gap: 28px;
   }
-  
-  .close-modal, .back-modal {
-    width: 36px;
-    height: 36px;
-    font-size: 1.3em;
-  }
-  
+
   .switch-card {
-    width: 90vw;
-    height: 90vw;
+    min-width: 100%;
+    min-height: clamp(320px, 70vw, 420px);
   }
+
   .wall-plate {
-    width: 40vw;
-    height: 60vw;
+    width: 100%;
+    height: clamp(340px, 68vw, 420px);
   }
-  .paddle-switch {
-    width: 30vw;
-    height: 20vw;
-  }
+
   .side-btns {
-    right: -20vw;
-    gap: 4vw;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    padding: 16px;
   }
-  
-  .modal {
-    width: 90vw;
-    height: 90vw;
+
+  .side-btn {
+    font-size: 1.6rem;
   }
-  
+
   .clock {
-    top: 10px;
-    left: 10px;
+    top: calc(var(--chrome-height) + 18px);
+    left: 18px;
   }
-  
-  .clock .date {
-    font-size: 0.7em;
+}
+
+@media (max-width: 480px) {
+  .side-btns {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
   }
-  
-  .clock .time {
-    font-size: 1.4em;
+
+  .chrome-btn span {
+    display: none;
   }
-} 
+
+  .chrome-btn {
+    padding-inline: 14px;
+  }
+}
 
 /* ========================================
    DARK THEME OVERRIDES
    ======================================== */
 
 .dark-theme {
-  background: linear-gradient(135deg, #1a1a1a, #2d2d2d) !important;
+  background: linear-gradient(160deg, #05070f 0%, #020309 100%) !important;
 }
-
 
 .dark-theme .clock {
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--text-primary);
 }
 
-.dark-theme .paddle-label { color: rgba(255, 255, 255, 0.9); }
+.dark-theme .paddle-label {
+  color: rgba(224, 236, 255, 0.85);
+}
+
+.dark-theme .switch-card {
+  background: rgba(8, 12, 24, 0.92);
+  border-color: rgba(125, 211, 252, 0.12);
+}
 
 .dark-theme .wall-plate {
-  background: linear-gradient(145deg, #2a2a2a, #1a1a1a);
-  box-shadow: 
-    8px 8px 16px rgba(0, 0, 0, 0.4),
-    -8px -8px 16px rgba(255, 255, 255, 0.05);
+  background: linear-gradient(170deg, rgba(22, 28, 50, 0.88), rgba(6, 10, 22, 0.92));
+  border-color: rgba(125, 211, 252, 0.08);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.12),
+    inset 0 -18px 28px rgba(6, 9, 20, 0.55),
+    0 20px 36px rgba(3, 6, 14, 0.65);
 }
 
 .dark-theme .paddle-switch {
-  background: linear-gradient(145deg, #3a3a3a, #2a2a2a);
-  color: #ffffff;
+  background: linear-gradient(180deg, rgba(36, 45, 72, 0.92), rgba(16, 22, 36, 0.9));
+  color: rgba(210, 224, 255, 0.82);
 }
 
 .dark-theme .paddle-switch.on {
-  background: linear-gradient(145deg, #4caf50, #388e3c);
-  box-shadow: 
-    inset 4px 4px 8px rgba(0, 0, 0, 0.3),
-    inset -4px -4px 8px rgba(255, 255, 255, 0.1);
+  background: linear-gradient(180deg, rgba(34, 197, 94, 0.92), rgba(16, 185, 129, 0.88));
+  color: rgba(5, 33, 21, 0.88);
+}
+
+.dark-theme .side-btns {
+  background: rgba(7, 12, 24, 0.9);
+  border-color: rgba(125, 211, 252, 0.1);
 }
 
 .dark-theme .side-btn {
-  background: linear-gradient(145deg, #3a3a3a, #2a2a2a);
-  color: #ffffff;
-  box-shadow: 
-    4px 4px 8px rgba(0, 0, 0, 0.4),
-    -4px -4px 8px rgba(255, 255, 255, 0.05);
-}
-
-.dark-theme .side-btn:hover {
-  background: linear-gradient(145deg, #4a4a4a, #3a3a3a);
-  transform: translateY(-2px);
-  box-shadow: 
-    6px 6px 12px rgba(0, 0, 0, 0.5),
-    -6px -6px 12px rgba(255, 255, 255, 0.08);
+  background: linear-gradient(160deg, rgba(34, 45, 70, 0.58), rgba(8, 12, 24, 0.86));
+  color: var(--text-primary);
 }
 
 .dark-theme .modal {
-  background: linear-gradient(145deg, #2a2a2a, #1a1a1a);
-  color: #ffffff;
-  box-shadow: 
-    0 20px 40px rgba(0, 0, 0, 0.6),
-    0 0 0 1px rgba(255, 255, 255, 0.1);
+  background: linear-gradient(170deg, rgba(12, 17, 32, 0.94), rgba(5, 9, 20, 0.94));
+  border-color: rgba(125, 211, 252, 0.12);
+  color: var(--text-primary);
 }
 
-.dark-theme .modal h2 {
-  color: #ffffff;
-}
-
-.dark-theme .modal p {
-  color: #cccccc;
-}
-
-.dark-theme .close-modal,
-.dark-theme .back-modal {
-  background: linear-gradient(145deg, #3a3a3a, #2a2a2a);
-  color: #ffffff;
-  box-shadow: 
-    2px 2px 4px rgba(0, 0, 0, 0.3),
-    -2px -2px 4px rgba(255, 255, 255, 0.05);
-}
-
-.dark-theme .close-modal:hover,
-.dark-theme .back-modal:hover {
-  background: linear-gradient(145deg, #4a4a4a, #3a3a3a);
-}
-
-.dark-theme input[type="range"] {
-  background: #3a3a3a;
-}
-
-.dark-theme input[type="range"]::-webkit-slider-thumb {
-  background: linear-gradient(145deg, #4a4a4a, #3a3a3a);
-  box-shadow: 
-    2px 2px 4px rgba(0, 0, 0, 0.3),
-    -2px -2px 4px rgba(255, 255, 255, 0.05);
-}
-
-.dark-theme input[type="range"]::-moz-range-thumb {
-  background: linear-gradient(145deg, #4a4a4a, #3a3a3a);
-  box-shadow: 
-    2px 2px 4px rgba(0, 0, 0, 0.3),
-    -2px -2px 4px rgba(255, 255, 255, 0.05);
-}
-
+.dark-theme label,
 .dark-theme button {
-  background: linear-gradient(145deg, #3a3a3a, #2a2a2a);
-  color: #ffffff;
-  box-shadow: 
-    2px 2px 4px rgba(0, 0, 0, 0.3),
-    -2px -2px 4px rgba(255, 255, 255, 0.05);
+  color: var(--text-primary);
 }
-
-.dark-theme button:hover {
-  background: linear-gradient(145deg, #4a4a4a, #3a3a3a);
-}
-
-.dark-theme label {
-  color: #ffffff;
-} 
 
 /* Scene-specific colors */
 .scene-white { background: #ffffff; color: #1a1a1a; }
@@ -1078,13 +1372,19 @@ button:focus-visible, input[type="range"]:focus-visible {
 }
 /* ---------- Side carousel container (left of wall plate) ---------- */
 #side-carousel-container {
-  position: fixed;          /* Float it; we'll place it via JS to align with plate */
+  position: fixed;          /* Float it; JS keeps it aligned with the wall plate */
   top: 50%;
   transform: translateY(-50%);
-  pointer-events: none;     /* hidden by default; enabled when visible */
-  z-index: 100;
+  pointer-events: none;
+  z-index: 900;
   opacity: 0;
-  transition: opacity 0.25s ease;
+  transition: opacity 0.28s ease;
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(14px);
+  overflow: hidden;
 }
 
 /* The scrolling rail itself */


### PR DESCRIPTION
## Summary
- introduce Vite-based build tooling with dashboard and settings entry modules under `src/pages`
- migrate legacy scripts, styles, and assets into the Vite pipeline and modernize dynamic imports and asset loading
- adjust Electron to load the built `dist/index.html` bundle and document the new workflow in the README

## Testing
- npm run build:frontend

------
https://chatgpt.com/codex/tasks/task_e_68c8b3d726cc8331ad1b02af717f030d