### PR TITLE
Add SwiftUI iOS client and Spotify auth proxy

### DIFF
--- a/docs/spotify-proxy/index.html
+++ b/docs/spotify-proxy/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Spotify Bridge</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main>
+      <h1>Spotify Bridge</h1>
+      <p id="status">Preparing…</p>
+    </main>
+    <script type="module" src="proxy.js"></script>
+  </body>
+</html>

--- a/docs/spotify-proxy/proxy.js
+++ b/docs/spotify-proxy/proxy.js
@@ -1,0 +1,156 @@
+const status = document.getElementById('status');
+const query = new URLSearchParams(window.location.search);
+const action = query.get('action');
+
+function setStatus(message) {
+  if (status) {
+    status.textContent = message;
+  }
+}
+
+const DEFAULT_SCOPE = 'user-read-private user-read-email streaming user-read-playback-state user-modify-playback-state';
+
+if (action === 'authorize') {
+  handleAuthorize();
+} else if (action === 'callback') {
+  handleCallback();
+} else {
+  setStatus('Loading Spotify proxy bridge…');
+  setupBridge();
+}
+
+function handleAuthorize() {
+  const clientId = query.get('client_id');
+  const redirectScheme = query.get('redirect_scheme');
+  const scope = query.get('scope') || DEFAULT_SCOPE;
+  const state = query.get('state') || crypto.randomUUID();
+
+  if (!clientId || !redirectScheme) {
+    setStatus('Missing client information.');
+    return;
+  }
+
+  const callback = new URL(window.location.href);
+  callback.searchParams.set('action', 'callback');
+  callback.searchParams.set('state', state);
+  callback.searchParams.set('redirect_scheme', redirectScheme);
+  callback.hash = '';
+
+  const authorizeUrl = new URL('https://accounts.spotify.com/authorize');
+  authorizeUrl.searchParams.set('client_id', clientId);
+  authorizeUrl.searchParams.set('response_type', 'token');
+  authorizeUrl.searchParams.set('redirect_uri', callback.toString());
+  authorizeUrl.searchParams.set('scope', scope);
+  authorizeUrl.searchParams.set('state', state);
+  authorizeUrl.searchParams.set('show_dialog', 'true');
+
+  setStatus('Redirecting to Spotify…');
+  window.location.replace(authorizeUrl.toString());
+}
+
+function handleCallback() {
+  const fragment = window.location.hash.startsWith('#')
+    ? window.location.hash.substring(1)
+    : '';
+  const params = new URLSearchParams(fragment);
+  const redirectScheme = query.get('redirect_scheme') || 'hubitatdashboard';
+  const state = query.get('state');
+
+  if (state && params.get('state') !== state) {
+    setStatus('State verification failed. Please restart authentication.');
+    return;
+  }
+
+  if (!params.get('access_token')) {
+    setStatus('Missing access token in Spotify response.');
+    return;
+  }
+
+  const redirectUrl = `${redirectScheme}://auth#${params.toString()}`;
+  setStatus('Returning control to the application…');
+  window.location.replace(redirectUrl);
+}
+
+function setupBridge() {
+  const pending = new Map();
+
+  window.spotifyBridge = {
+    performEncodedRequest(base64) {
+      try {
+        const decoded = JSON.parse(atob(base64));
+        processRequest(decoded);
+      } catch (error) {
+        console.error('Failed to decode request', error);
+      }
+    }
+  };
+
+  setStatus('Bridge ready. Waiting for commands…');
+
+  async function processRequest(request) {
+    const { id, method, path, body, accessToken } = request;
+    if (!id || !method || !path || !accessToken) {
+      return respond({ id, status: 400, error: 'Invalid request payload.' });
+    }
+
+    try {
+      const endpoint = new URL(path, 'https://api.spotify.com');
+      const headers = new Headers({
+        Authorization: `Bearer ${accessToken}`
+      });
+      if (body) {
+        headers.set('Content-Type', 'application/json');
+      }
+
+      const response = await fetch(endpoint.toString(), {
+        method,
+        headers,
+        body: body ? decodeBase64(body) : undefined
+      });
+
+      const buffer = await response.arrayBuffer();
+      const base64Body = buffer.byteLength ? encodeBase64(buffer) : null;
+
+      if (!response.ok) {
+        const errorText = buffer.byteLength
+          ? new TextDecoder().decode(new Uint8Array(buffer))
+          : response.statusText;
+        return respond({ id, status: response.status, error: errorText });
+      }
+
+      respond({ id, status: response.status, body: base64Body });
+    } catch (error) {
+      respond({ id: request.id, status: 500, error: error.message });
+    }
+  }
+
+  function respond(payload) {
+    const channel = window.webkit?.messageHandlers?.spotifyProxy;
+    const encoded = btoa(JSON.stringify(payload));
+    if (channel && typeof channel.postMessage === 'function') {
+      channel.postMessage(encoded);
+    } else {
+      console.log('Bridge response', payload);
+    }
+  }
+}
+
+function encodeBase64(buffer) {
+  let binary = '';
+  const bytes = new Uint8Array(buffer);
+  const len = bytes.byteLength;
+  for (let i = 0; i < len; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+function decodeBase64(base64) {
+  const binaryString = atob(base64);
+  const len = binaryString.length;
+  const bytes = new Uint8Array(len);
+  for (let i = 0; i < len; i += 1) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return bytes;
+}

--- a/docs/spotify-proxy/styles.css
+++ b/docs/spotify-proxy/styles.css
@@ -1,0 +1,35 @@
+:root {
+  color-scheme: light dark;
+  font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: canvas;
+  color: canvastext;
+}
+
+body {
+  margin: 0;
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+}
+
+main {
+  padding: 2rem;
+  border-radius: 1.25rem;
+  border: 1px solid color-mix(in srgb, canvastext 15%, transparent);
+  box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.08);
+  max-width: 32rem;
+  text-align: center;
+}
+
+h1 {
+  margin-top: 0;
+}
+
+p {
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+code {
+  font-family: "SF Mono", ui-monospace, "Menlo", monospace;
+}

--- a/ios/HubitatDashboard/HubitatDashboard.xcodeproj/project.pbxproj
+++ b/ios/HubitatDashboard/HubitatDashboard.xcodeproj/project.pbxproj
@@ -1,0 +1,420 @@
+// !$*UTF8*$!
+{
+archiveVersion = 1;
+classes = {};
+objectVersion = 56;
+objects = {
+
+/* Begin PBXBuildFile section */
+1C2A527A2C3F1B4A00C9E0A1 /* HubitatDashboardApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C2A52692C3F1B4A00C9E0A1 /* HubitatDashboardApp.swift */; };
+1C2A527B2C3F1B4A00C9E0A1 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C2A526A2C3F1B4A00C9E0A1 /* ContentView.swift */; };
+1C2A527C2C3F1B4A00C9E0A1 /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C2A526B2C3F1B4A00C9E0A1 /* DashboardView.swift */; };
+1C2A527D2C3F1B4A00C9E0A1 /* DeviceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C2A526C2C3F1B4A00C9E0A1 /* DeviceDetailView.swift */; };
+1C2A527E2C3F1B4A00C9E0A1 /* DeviceRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C2A526D2C3F1B4A00C9E0A1 /* DeviceRow.swift */; };
+1C2A527F2C3F1B4A00C9E0A1 /* SpotifyPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C2A526E2C3F1B4A00C9E0A1 /* SpotifyPlayerView.swift */; };
+1C2A52802C3F1B4A00C9E0A1 /* DashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C2A526F2C3F1B4A00C9E0A1 /* DashboardViewModel.swift */; };
+1C2A52812C3F1B4A00C9E0A1 /* HubitatService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C2A52702C3F1B4A00C9E0A1 /* HubitatService.swift */; };
+1C2A52822C3F1B4A00C9E0A1 /* WebSocketClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C2A52712C3F1B4A00C9E0A1 /* WebSocketClient.swift */; };
+1C2A52832C3F1B4A00C9E0A1 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C2A52722C3F1B4A00C9E0A1 /* AppConfiguration.swift */; };
+1C2A52842C3F1B4A00C9E0A1 /* SpotifyPlaybackState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C2A52732C3F1B4A00C9E0A1 /* SpotifyPlaybackState.swift */; };
+1C2A52852C3F1B4A00C9E0A1 /* DeviceState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C2A52742C3F1B4A00C9E0A1 /* DeviceState.swift */; };
+1C2A52862C3F1B4A00C9E0A1 /* SpotifyAuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C2A52752C3F1B4A00C9E0A1 /* SpotifyAuthManager.swift */; };
+1C2A52872C3F1B4A00C9E0A1 /* SpotifyProxyClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C2A52762C3F1B4A00C9E0A1 /* SpotifyProxyClient.swift */; };
+1C2A52882C3F1B4A00C9E0A1 /* SpotifyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C2A52772C3F1B4A00C9E0A1 /* SpotifyService.swift */; };
+1C2A52892C3F1B4A00C9E0A1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1C2A52782C3F1B4A00C9E0A1 /* Assets.xcassets */; };
+1C2A528A2C3F1B4A00C9E0A1 /* AppConfiguration.example.plist in Resources */ = {isa = PBXBuildFile; fileRef = 1C2A52792C3F1B4A00C9E0A1 /* AppConfiguration.example.plist */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+1C2A52692C3F1B4A00C9E0A1 /* HubitatDashboardApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubitatDashboardApp.swift; sourceTree = "<group>"; };
+1C2A526A2C3F1B4A00C9E0A1 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+1C2A526B2C3F1B4A00C9E0A1 /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
+1C2A526C2C3F1B4A00C9E0A1 /* DeviceDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceDetailView.swift; sourceTree = "<group>"; };
+1C2A526D2C3F1B4A00C9E0A1 /* DeviceRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceRow.swift; sourceTree = "<group>"; };
+1C2A526E2C3F1B4A00C9E0A1 /* SpotifyPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotifyPlayerView.swift; sourceTree = "<group>"; };
+1C2A526F2C3F1B4A00C9E0A1 /* DashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewModel.swift; sourceTree = "<group>"; };
+1C2A52702C3F1B4A00C9E0A1 /* HubitatService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubitatService.swift; sourceTree = "<group>"; };
+1C2A52712C3F1B4A00C9E0A1 /* WebSocketClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketClient.swift; sourceTree = "<group>"; };
+1C2A52722C3F1B4A00C9E0A1 /* AppConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
+1C2A52732C3F1B4A00C9E0A1 /* SpotifyPlaybackState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotifyPlaybackState.swift; sourceTree = "<group>"; };
+1C2A52742C3F1B4A00C9E0A1 /* DeviceState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceState.swift; sourceTree = "<group>"; };
+1C2A52752C3F1B4A00C9E0A1 /* SpotifyAuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotifyAuthManager.swift; sourceTree = "<group>"; };
+1C2A52762C3F1B4A00C9E0A1 /* SpotifyProxyClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotifyProxyClient.swift; sourceTree = "<group>"; };
+1C2A52772C3F1B4A00C9E0A1 /* SpotifyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotifyService.swift; sourceTree = "<group>"; };
+1C2A52782C3F1B4A00C9E0A1 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+1C2A52792C3F1B4A00C9E0A1 /* AppConfiguration.example.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = AppConfiguration.example.plist; sourceTree = "<group>"; };
+1C2A527A2C3F1B4B00C9E0A1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+1C2A52912C3F1B4A00C9E0A1 /* HubitatDashboard.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; path = HubitatDashboard.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+1C2A52642C3F1B4A00C9E0A1 /* Frameworks */ = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = ();
+};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+1C2A52602C3F1B4A00C9E0A1 = {
+isa = PBXGroup;
+children = (
+1C2A52682C3F1B4A00C9E0A1 /* HubitatDashboard */,
+1C2A52902C3F1B4A00C9E0A1 /* Products */,
+);
+sourceTree = "<group>";
+};
+1C2A52682C3F1B4A00C9E0A1 /* HubitatDashboard */ = {
+isa = PBXGroup;
+children = (
+1C2A52692C3F1B4A00C9E0A1 /* HubitatDashboardApp.swift */,
+1C2A526A2C3F1B4A00C9E0A1 /* ContentView.swift */,
+1C2A527B2C3F1B4B00C9E0A1 /* Core */,
+1C2A527C2C3F1B4B00C9E0A1 /* Models */,
+1C2A527D2C3F1B4B00C9E0A1 /* ViewModels */,
+1C2A527E2C3F1B4B00C9E0A1 /* Views */,
+1C2A527F2C3F1B4B00C9E0A1 /* Services */,
+1C2A52802C3F1B4B00C9E0A1 /* Resources */,
+1C2A52812C3F1B4B00C9E0A1 /* Support */,
+);
+path = HubitatDashboard;
+sourceTree = "<group>";
+};
+1C2A527B2C3F1B4B00C9E0A1 /* Core */ = {
+isa = PBXGroup;
+children = (
+1C2A52722C3F1B4A00C9E0A1 /* AppConfiguration.swift */,
+);
+path = Core;
+sourceTree = "<group>";
+};
+1C2A527C2C3F1B4B00C9E0A1 /* Models */ = {
+isa = PBXGroup;
+children = (
+1C2A52732C3F1B4A00C9E0A1 /* SpotifyPlaybackState.swift */,
+1C2A52742C3F1B4A00C9E0A1 /* DeviceState.swift */,
+);
+path = Models;
+sourceTree = "<group>";
+};
+1C2A527D2C3F1B4B00C9E0A1 /* ViewModels */ = {
+isa = PBXGroup;
+children = (
+1C2A526F2C3F1B4A00C9E0A1 /* DashboardViewModel.swift */,
+);
+path = ViewModels;
+sourceTree = "<group>";
+};
+1C2A527E2C3F1B4B00C9E0A1 /* Views */ = {
+isa = PBXGroup;
+children = (
+1C2A526B2C3F1B4A00C9E0A1 /* DashboardView.swift */,
+1C2A526C2C3F1B4A00C9E0A1 /* DeviceDetailView.swift */,
+1C2A526D2C3F1B4A00C9E0A1 /* DeviceRow.swift */,
+1C2A526E2C3F1B4A00C9E0A1 /* SpotifyPlayerView.swift */,
+);
+path = Views;
+sourceTree = "<group>";
+};
+1C2A527F2C3F1B4B00C9E0A1 /* Services */ = {
+isa = PBXGroup;
+children = (
+1C2A52822C3F1B4B00C9E0A1 /* Spotify */,
+1C2A52702C3F1B4A00C9E0A1 /* HubitatService.swift */,
+1C2A52712C3F1B4A00C9E0A1 /* WebSocketClient.swift */,
+);
+path = Services;
+sourceTree = "<group>";
+};
+1C2A52822C3F1B4B00C9E0A1 /* Spotify */ = {
+isa = PBXGroup;
+children = (
+1C2A52752C3F1B4A00C9E0A1 /* SpotifyAuthManager.swift */,
+1C2A52762C3F1B4A00C9E0A1 /* SpotifyProxyClient.swift */,
+1C2A52772C3F1B4A00C9E0A1 /* SpotifyService.swift */,
+);
+path = Spotify;
+sourceTree = "<group>";
+};
+1C2A52802C3F1B4B00C9E0A1 /* Resources */ = {
+isa = PBXGroup;
+children = (
+1C2A52782C3F1B4A00C9E0A1 /* Assets.xcassets */,
+);
+path = Resources;
+sourceTree = "<group>";
+};
+1C2A52812C3F1B4B00C9E0A1 /* Support */ = {
+isa = PBXGroup;
+children = (
+1C2A52792C3F1B4A00C9E0A1 /* AppConfiguration.example.plist */,
+1C2A527A2C3F1B4B00C9E0A1 /* Info.plist */,
+);
+path = Support;
+sourceTree = "<group>";
+};
+1C2A52902C3F1B4A00C9E0A1 /* Products */ = {
+isa = PBXGroup;
+children = (
+1C2A52912C3F1B4A00C9E0A1 /* HubitatDashboard.app */,
+);
+name = Products;
+sourceTree = "<group>";
+};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+1C2A52652C3F1B4A00C9E0A1 /* HubitatDashboard */ = {
+isa = PBXNativeTarget;
+buildConfigurationList = 1C2A528F2C3F1B4A00C9E0A1 /* Build configuration list for PBXNativeTarget "HubitatDashboard" */;
+buildPhases = (
+1C2A52622C3F1B4A00C9E0A1 /* Sources */,
+1C2A52632C3F1B4A00C9E0A1 /* Resources */,
+1C2A52642C3F1B4A00C9E0A1 /* Frameworks */,
+);
+buildRules = (
+);
+dependencies = (
+);
+name = HubitatDashboard;
+productName = HubitatDashboard;
+productReference = 1C2A52912C3F1B4A00C9E0A1 /* HubitatDashboard.app */;
+productType = "com.apple.product-type.application";
+};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+1C2A52612C3F1B4A00C9E0A1 /* Project object */ = {
+isa = PBXProject;
+attributes = {
+BuildIndependentTargetsInParallel = 1;
+LastSwiftUpdateCheck = 1520;
+LastUpgradeCheck = 1520;
+TargetAttributes = {
+1C2A52652C3F1B4A00C9E0A1 = {
+CreatedOnToolsVersion = 15.2;
+};
+};
+};
+buildConfigurationList = 1C2A528E2C3F1B4A00C9E0A1 /* Build configuration list for PBXProject "HubitatDashboard" */;
+compatibilityVersion = "Xcode 14.0";
+developmentRegion = en;
+hasScannedForEncodings = 0;
+knownRegions = (
+en,
+Base,
+);
+mainGroup = 1C2A52602C3F1B4A00C9E0A1;
+productRefGroup = 1C2A52902C3F1B4A00C9E0A1 /* Products */;
+projectDirPath = "";
+projectRoot = "";
+targets = (
+1C2A52652C3F1B4A00C9E0A1 /* HubitatDashboard */,
+);
+};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+1C2A52632C3F1B4A00C9E0A1 /* Resources */ = {
+isa = PBXResourcesBuildPhase;
+buildActionMask = 2147483647;
+files = (
+1C2A52892C3F1B4A00C9E0A1 /* Assets.xcassets in Resources */,
+1C2A528A2C3F1B4A00C9E0A1 /* AppConfiguration.example.plist in Resources */,
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+1C2A52622C3F1B4A00C9E0A1 /* Sources */ = {
+isa = PBXSourcesBuildPhase;
+buildActionMask = 2147483647;
+files = (
+1C2A52882C3F1B4A00C9E0A1 /* SpotifyService.swift in Sources */,
+1C2A527A2C3F1B4A00C9E0A1 /* HubitatDashboardApp.swift in Sources */,
+1C2A52812C3F1B4A00C9E0A1 /* HubitatService.swift in Sources */,
+1C2A52842C3F1B4A00C9E0A1 /* SpotifyPlaybackState.swift in Sources */,
+1C2A527E2C3F1B4A00C9E0A1 /* DeviceRow.swift in Sources */,
+1C2A52832C3F1B4A00C9E0A1 /* AppConfiguration.swift in Sources */,
+1C2A52872C3F1B4A00C9E0A1 /* SpotifyProxyClient.swift in Sources */,
+1C2A52802C3F1B4A00C9E0A1 /* DashboardViewModel.swift in Sources */,
+1C2A52862C3F1B4A00C9E0A1 /* SpotifyAuthManager.swift in Sources */,
+1C2A527B2C3F1B4A00C9E0A1 /* ContentView.swift in Sources */,
+1C2A527D2C3F1B4A00C9E0A1 /* DashboardView.swift in Sources */,
+1C2A527F2C3F1B4A00C9E0A1 /* SpotifyPlayerView.swift in Sources */,
+1C2A52822C3F1B4A00C9E0A1 /* WebSocketClient.swift in Sources */,
+1C2A527C2C3F1B4A00C9E0A1 /* DeviceDetailView.swift in Sources */,
+1C2A52852C3F1B4A00C9E0A1 /* DeviceState.swift in Sources */,
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+1C2A528B2C3F1B4A00C9E0A1 /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_SEARCH_USER_PATHS = NO;
+CLANG_ANALYZER_NONNULL = YES;
+CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+CLANG_ENABLE_MODULES = YES;
+CLANG_ENABLE_OBJC_ARC = YES;
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+CLANG_WARN_BOOL_CONVERSION = YES;
+CLANG_WARN_COMMA = YES;
+CLANG_WARN_CONSTANT_CONVERSION = YES;
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+CLANG_WARN_EMPTY_BODY = YES;
+CLANG_WARN_ENUM_CONVERSION = YES;
+CLANG_WARN_INFINITE_RECURSION = YES;
+CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+CLANG_WARN_STRICT_PROTOTYPES = YES;
+CLANG_WARN_SUSPICIOUS_MOVE = YES;
+CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+CODE_SIGN_STYLE = Automatic;
+COPY_PHASE_STRIP = NO;
+CURRENT_PROJECT_VERSION = 1;
+DEBUG_INFORMATION_FORMAT = dwarf;
+ENABLE_STRICT_OBJC_MSGSEND = YES;
+ENABLE_TESTABILITY = YES;
+GCC_C_LANGUAGE_STANDARD = gnu11;
+GCC_DYNAMIC_NO_PIC = NO;
+GCC_NO_COMMON_BLOCKS = YES;
+GCC_OPTIMIZATION_LEVEL = 0;
+GCC_PREPROCESSOR_DEFINITIONS = (
+"DEBUG=1",
+"$(inherited)",
+);
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+GCC_WARN_UNDECLARED_SELECTOR = YES;
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+GCC_WARN_UNUSED_FUNCTION = YES;
+GCC_WARN_UNUSED_VARIABLE = YES;
+IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+ONLY_ACTIVE_ARCH = YES;
+SDKROOT = iphoneos;
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+TARGETED_DEVICE_FAMILY = "1,2";
+};
+name = Debug;
+};
+1C2A528C2C3F1B4A00C9E0A1 /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_SEARCH_USER_PATHS = NO;
+CLANG_ANALYZER_NONNULL = YES;
+CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+CLANG_ENABLE_MODULES = YES;
+CLANG_ENABLE_OBJC_ARC = YES;
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+CLANG_WARN_BOOL_CONVERSION = YES;
+CLANG_WARN_COMMA = YES;
+CLANG_WARN_CONSTANT_CONVERSION = YES;
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+CLANG_WARN_EMPTY_BODY = YES;
+CLANG_WARN_ENUM_CONVERSION = YES;
+CLANG_WARN_INFINITE_RECURSION = YES;
+CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+CLANG_WARN_STRICT_PROTOTYPES = YES;
+CLANG_WARN_SUSPICIOUS_MOVE = YES;
+CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+CODE_SIGN_STYLE = Automatic;
+COPY_PHASE_STRIP = NO;
+CURRENT_PROJECT_VERSION = 1;
+DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+ENABLE_NS_ASSERTIONS = NO;
+ENABLE_STRICT_OBJC_MSGSEND = YES;
+GCC_C_LANGUAGE_STANDARD = gnu11;
+GCC_NO_COMMON_BLOCKS = YES;
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+GCC_WARN_UNDECLARED_SELECTOR = YES;
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+GCC_WARN_UNUSED_FUNCTION = YES;
+GCC_WARN_UNUSED_VARIABLE = YES;
+IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+MTL_ENABLE_DEBUG_INFO = NO;
+SDKROOT = iphoneos;
+SWIFT_COMPILATION_MODE = wholemodule;
+SWIFT_OPTIMIZATION_LEVEL = "-O";
+TARGETED_DEVICE_FAMILY = "1,2";
+VALIDATE_PRODUCT = YES;
+};
+name = Release;
+};
+1C2A528D2C3F1B4A00C9E0A1 /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+CODE_SIGN_STYLE = Automatic;
+INFOPLIST_FILE = HubitatDashboard/Support/Info.plist;
+IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+PRODUCT_BUNDLE_IDENTIFIER = com.example.hubitatdashboard;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_EMIT_LOC_STRINGS = YES;
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = "1,2";
+};
+name = Debug;
+};
+1C2A528E2C3F1B4A00C9E0A1 /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+CODE_SIGN_STYLE = Automatic;
+INFOPLIST_FILE = HubitatDashboard/Support/Info.plist;
+IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+PRODUCT_BUNDLE_IDENTIFIER = com.example.hubitatdashboard;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_EMIT_LOC_STRINGS = YES;
+SWIFT_VERSION = 5.0;
+TARGETED_DEVICE_FAMILY = "1,2";
+};
+name = Release;
+};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+1C2A528E2C3F1B4A00C9E0A1 /* Build configuration list for PBXProject "HubitatDashboard" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+1C2A528B2C3F1B4A00C9E0A1 /* Debug */,
+1C2A528C2C3F1B4A00C9E0A1 /* Release */,
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
+1C2A528F2C3F1B4A00C9E0A1 /* Build configuration list for PBXNativeTarget "HubitatDashboard" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+1C2A528D2C3F1B4A00C9E0A1 /* Debug */,
+1C2A528E2C3F1B4A00C9E0A1 /* Release */,
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
+/* End XCConfigurationList section */
+};
+rootObject = 1C2A52612C3F1B4A00C9E0A1 /* Project object */;
+}

--- a/ios/HubitatDashboard/HubitatDashboard/ContentView.swift
+++ b/ios/HubitatDashboard/HubitatDashboard/ContentView.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+struct ContentView: View {
+    @EnvironmentObject private var viewModel: DashboardViewModel
+    @Environment(\.appConfiguration) private var configuration
+
+    var body: some View {
+        NavigationStack {
+            DashboardView()
+                .navigationTitle("Hubitat Dashboard")
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Menu {
+                            Button("Refresh Devices") {
+                                Task { await viewModel.refreshDevices() }
+                            }
+                            Button("Reconnect WebSocket") {
+                                viewModel.reconnectWebSocket()
+                            }
+                            Divider()
+                            Button(viewModel.spotifyIsAuthenticated ? "Sign out of Spotify" : "Sign in to Spotify") {
+                                Task {
+                                    if viewModel.spotifyIsAuthenticated {
+                                        await viewModel.logoutSpotify()
+                                    } else {
+                                        await viewModel.authenticateSpotify(from: configuration)
+                                    }
+                                }
+                            }
+                        } label: {
+                            Image(systemName: "ellipsis.circle")
+                        }
+                    }
+                }
+        }
+        .task {
+            await viewModel.bootstrapIfNeeded(configuration: configuration)
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+        .environmentObject(DashboardViewModel(preview: true))
+        .environment(\.appConfiguration, AppConfiguration.preview)
+}

--- a/ios/HubitatDashboard/HubitatDashboard/Core/AppConfiguration.swift
+++ b/ios/HubitatDashboard/HubitatDashboard/Core/AppConfiguration.swift
@@ -1,0 +1,50 @@
+import Foundation
+import SwiftUI
+
+struct AppConfiguration: Equatable {
+    var backendBaseURL: URL
+    var webSocketURL: URL
+    var githubProxyBaseURL: URL
+    var spotifyClientID: String
+    var spotifyRedirectScheme: String
+
+    static func loadDefault(bundle: Bundle = .main) -> AppConfiguration {
+        guard
+            let url = bundle.url(forResource: "AppConfiguration", withExtension: "plist"),
+            let data = try? Data(contentsOf: url),
+            let dict = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
+        else {
+            assertionFailure("Missing AppConfiguration.plist in bundle")
+            return preview
+        }
+
+        return AppConfiguration(
+            backendBaseURL: URL(string: dict["BackendBaseURL"] as? String ?? "https://localhost:4711")!,
+            webSocketURL: URL(string: dict["WebSocketURL"] as? String ?? "wss://localhost:4712")!,
+            githubProxyBaseURL: URL(string: dict["GithubProxyBaseURL"] as? String ?? "https://yourname.github.io/spotify-proxy")!,
+            spotifyClientID: dict["SpotifyClientID"] as? String ?? "",
+            spotifyRedirectScheme: dict["SpotifyRedirectScheme"] as? String ?? "hubitatdashboard"
+        )
+    }
+
+    static var preview: AppConfiguration {
+        AppConfiguration(
+            backendBaseURL: URL(string: "https://localhost:4711")!,
+            webSocketURL: URL(string: "wss://localhost:4712")!,
+            githubProxyBaseURL: URL(string: "https://example.github.io/spotify-proxy")!,
+            spotifyClientID: "preview-client-id",
+            spotifyRedirectScheme: "hubitatdashboard"
+        )
+    }
+}
+
+private struct AppConfigurationKey: EnvironmentKey {
+    static let defaultValue = AppConfiguration.preview
+}
+
+extension EnvironmentValues {
+    var appConfiguration: AppConfiguration {
+        get { self[AppConfigurationKey.self] }
+        set { self[AppConfigurationKey.self] = newValue }
+    }
+}

--- a/ios/HubitatDashboard/HubitatDashboard/HubitatDashboardApp.swift
+++ b/ios/HubitatDashboard/HubitatDashboard/HubitatDashboardApp.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+@main
+struct HubitatDashboardApp: App {
+    @StateObject private var viewModel = DashboardViewModel()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(viewModel)
+                .environment(\.appConfiguration, AppConfiguration.loadDefault())
+        }
+    }
+}

--- a/ios/HubitatDashboard/HubitatDashboard/Models/DeviceState.swift
+++ b/ios/HubitatDashboard/HubitatDashboard/Models/DeviceState.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+struct DeviceState: Identifiable, Codable, Hashable {
+    var id: String { deviceId }
+    let deviceId: String
+    let label: String
+    var attributes: [String: AttributeValue]
+
+    struct AttributeValue: Codable, Hashable {
+        let name: String
+        let value: String
+        let unit: String?
+        let lastUpdated: Date?
+
+        init(name: String, value: String, unit: String? = nil, lastUpdated: Date? = nil) {
+            self.name = name
+            self.value = value
+            self.unit = unit
+            self.lastUpdated = lastUpdated
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case name
+            case value
+            case unit
+            case lastUpdated
+        }
+    }
+}
+
+extension DeviceState {
+    static let previewDevices: [DeviceState] = [
+        DeviceState(
+            deviceId: "1",
+            label: "Bedroom Lights",
+            attributes: [
+                "switch": AttributeValue(name: "switch", value: "on"),
+                "level": AttributeValue(name: "level", value: "85", unit: "%")
+            ]
+        ),
+        DeviceState(
+            deviceId: "2",
+            label: "Thermostat",
+            attributes: [
+                "temperature": AttributeValue(name: "temperature", value: "21", unit: "°C"),
+                "heatingSetpoint": AttributeValue(name: "heatingSetpoint", value: "19", unit: "°C")
+            ]
+        )
+    ]
+}

--- a/ios/HubitatDashboard/HubitatDashboard/Models/SpotifyPlaybackState.swift
+++ b/ios/HubitatDashboard/HubitatDashboard/Models/SpotifyPlaybackState.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+struct SpotifyPlaybackState: Codable, Equatable {
+    struct Track: Codable, Equatable, Identifiable {
+        var id: String { uri }
+        let uri: String
+        let name: String
+        let artist: String
+        let album: String
+        let artworkURL: URL?
+    }
+
+    let isPlaying: Bool
+    let progress: TimeInterval
+    let duration: TimeInterval
+    let track: Track
+    let volume: Double
+
+    static let preview = SpotifyPlaybackState(
+        isPlaying: true,
+        progress: 42,
+        duration: 180,
+        track: Track(
+            uri: "spotify:track:preview",
+            name: "Preview Song",
+            artist: "Preview Artist",
+            album: "Preview Album",
+            artworkURL: URL(string: "https://via.placeholder.com/300")
+        ),
+        volume: 0.4
+    )
+}

--- a/ios/HubitatDashboard/HubitatDashboard/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/HubitatDashboard/HubitatDashboard/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/HubitatDashboard/HubitatDashboard/Resources/Assets.xcassets/Contents.json
+++ b/ios/HubitatDashboard/HubitatDashboard/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/HubitatDashboard/HubitatDashboard/Resources/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/ios/HubitatDashboard/HubitatDashboard/Resources/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/HubitatDashboard/HubitatDashboard/Services/HubitatService.swift
+++ b/ios/HubitatDashboard/HubitatDashboard/Services/HubitatService.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+actor HubitatService {
+    private let baseURL: URL
+    private let decoder: JSONDecoder
+
+    init(baseURL: URL) {
+        self.baseURL = baseURL
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .iso8601
+        self.decoder = decoder
+    }
+
+    func fetchDevices() async throws -> [DeviceState] {
+        let url = baseURL.appending(path: "/devices")
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw ServiceError.invalidResponse
+        }
+        return try decoder.decode([DeviceState].self, from: data)
+    }
+
+    enum ServiceError: Error {
+        case invalidResponse
+    }
+}

--- a/ios/HubitatDashboard/HubitatDashboard/Services/Spotify/SpotifyAuthManager.swift
+++ b/ios/HubitatDashboard/HubitatDashboard/Services/Spotify/SpotifyAuthManager.swift
@@ -1,0 +1,147 @@
+import AuthenticationServices
+import Foundation
+import SwiftUI
+import UIKit
+
+@MainActor
+final class SpotifyAuthManager: NSObject {
+    struct Token: Codable {
+        let accessToken: String
+        let expiresAt: Date
+
+        var isValid: Bool {
+            Date() < expiresAt.addingTimeInterval(-60)
+        }
+    }
+
+    enum AuthError: Error {
+        case invalidCallback
+        case cancelled
+        case presentationAnchor
+    }
+
+    private let configuration: AppConfiguration
+    private var token: Token? {
+        didSet { persistToken() }
+    }
+
+    private let storageKey = "spotify-auth-token"
+
+    init(configuration: AppConfiguration) {
+        self.configuration = configuration
+        super.init()
+        loadToken()
+    }
+
+    var currentToken: Token? {
+        guard let token, token.isValid else { return nil }
+        return token
+    }
+
+    var isAuthorized: Bool {
+        currentToken != nil
+    }
+
+    func authorize() async throws -> Token {
+        if let token = currentToken {
+            return token
+        }
+
+        let state = UUID().uuidString
+        let scope = "user-read-private user-read-email streaming user-read-playback-state user-modify-playback-state"
+
+        guard let authorizeURL = SpotifyProxyClient.authorizeURL(
+            baseURL: configuration.githubProxyBaseURL,
+            clientID: configuration.spotifyClientID,
+            redirectScheme: configuration.spotifyRedirectScheme,
+            state: state,
+            scope: scope
+        ) else {
+            throw AuthError.invalidCallback
+        }
+
+        let callbackScheme = configuration.spotifyRedirectScheme
+
+        return try await withCheckedThrowingContinuation { [weak self] continuation in
+            guard let self else { return continuation.resume(throwing: AuthError.presentationAnchor) }
+
+            let session = ASWebAuthenticationSession(url: authorizeURL, callbackURLScheme: callbackScheme) { callbackURL, error in
+                if let error = error as? ASWebAuthenticationSessionError, error.code == .canceledLogin {
+                    continuation.resume(throwing: AuthError.cancelled)
+                    return
+                }
+
+                guard let callbackURL else {
+                    continuation.resume(throwing: AuthError.invalidCallback)
+                    return
+                }
+
+                guard let components = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false),
+                      let fragment = components.fragment else {
+                    continuation.resume(throwing: AuthError.invalidCallback)
+                    return
+                }
+
+                let params = Self.parse(fragment: fragment)
+
+                guard params["state"] == state,
+                      let accessToken = params["access_token"],
+                      let expiresInString = params["expires_in"],
+                      let expiresIn = TimeInterval(expiresInString) else {
+                    continuation.resume(throwing: AuthError.invalidCallback)
+                    return
+                }
+
+                let token = Token(accessToken: accessToken, expiresAt: Date().addingTimeInterval(expiresIn))
+                self.token = token
+                continuation.resume(returning: token)
+            }
+
+            session.prefersEphemeralWebBrowserSession = true
+            session.presentationContextProvider = self
+            if !session.start() {
+                continuation.resume(throwing: AuthError.presentationAnchor)
+            }
+        }
+    }
+
+    func logout() {
+        token = nil
+    }
+
+    private func persistToken() {
+        guard let token else {
+            UserDefaults.standard.removeObject(forKey: storageKey)
+            return
+        }
+        if let data = try? JSONEncoder().encode(token) {
+            UserDefaults.standard.set(data, forKey: storageKey)
+        }
+    }
+
+    private func loadToken() {
+        guard let data = UserDefaults.standard.data(forKey: storageKey),
+              let token = try? JSONDecoder().decode(Token.self, from: data) else { return }
+        self.token = token
+    }
+
+    private static func parse(fragment: String) -> [String: String] {
+        fragment
+            .split(separator: "&")
+            .reduce(into: [String: String]()) { result, pair in
+                let parts = pair.split(separator: "=", maxSplits: 1).map(String.init)
+                guard parts.count == 2 else { return }
+                result[parts[0]] = parts[1].removingPercentEncoding ?? parts[1]
+            }
+    }
+}
+
+extension SpotifyAuthManager: ASWebAuthenticationPresentationContextProviding {
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let window = scene.windows.first else {
+            return UIWindow()
+        }
+        return window
+    }
+}

--- a/ios/HubitatDashboard/HubitatDashboard/Services/Spotify/SpotifyProxyClient.swift
+++ b/ios/HubitatDashboard/HubitatDashboard/Services/Spotify/SpotifyProxyClient.swift
@@ -1,0 +1,150 @@
+import Foundation
+import WebKit
+
+@MainActor
+final class SpotifyProxyClient: NSObject {
+    struct Request: Codable {
+        let id: String
+        let method: String
+        let path: String
+        let body: String?
+        let accessToken: String
+    }
+
+    struct Response: Decodable {
+        let id: String
+        let status: Int
+        let body: String?
+        let error: String?
+    }
+
+    enum ProxyError: Error {
+        case bridgeUnavailable
+        case invalidResponse
+        case requestFailed(status: Int, body: String?)
+    }
+
+    private let configuration: AppConfiguration
+    private let webView: WKWebView
+    private var isBridgeReady = false
+    private var bridgeContinuation: CheckedContinuation<Void, Error>?
+    private var pendingRequests: [String: CheckedContinuation<Data, Error>] = [:]
+
+    init(configuration: AppConfiguration) {
+        self.configuration = configuration
+
+        let contentController = WKUserContentController()
+        let config = WKWebViewConfiguration()
+        config.userContentController = contentController
+        config.preferences.javaScriptCanOpenWindowsAutomatically = false
+        config.defaultWebpagePreferences.allowsContentJavaScript = true
+
+        self.webView = WKWebView(frame: .zero, configuration: config)
+
+        super.init()
+
+        contentController.add(self, name: "spotifyProxy")
+        webView.navigationDelegate = self
+    }
+
+    deinit {
+        webView.configuration.userContentController.removeScriptMessageHandler(forName: "spotifyProxy")
+    }
+
+    static func authorizeURL(baseURL: URL, clientID: String, redirectScheme: String, state: String, scope: String) -> URL? {
+        var components = URLComponents(url: baseURL.appending(path: "index.html"), resolvingAgainstBaseURL: false)
+        components?.queryItems = [
+            URLQueryItem(name: "action", value: "authorize"),
+            URLQueryItem(name: "client_id", value: clientID),
+            URLQueryItem(name: "redirect_scheme", value: redirectScheme),
+            URLQueryItem(name: "scope", value: scope),
+            URLQueryItem(name: "state", value: state)
+        ]
+        return components?.url
+    }
+
+    func ensureBridgeLoaded() async throws {
+        if isBridgeReady { return }
+
+        try await withCheckedThrowingContinuation { continuation in
+            bridgeContinuation = continuation
+            var components = URLComponents(url: configuration.githubProxyBaseURL.appending(path: "index.html"), resolvingAgainstBaseURL: false)
+            components?.queryItems = [URLQueryItem(name: "action", value: "bridge")]
+            guard let url = components?.url else {
+                continuation.resume(throwing: ProxyError.bridgeUnavailable)
+                return
+            }
+            webView.load(URLRequest(url: url))
+        }
+    }
+
+    func perform(method: String, path: String, body: Data? = nil, accessToken: String) async throws -> Data {
+        try await ensureBridgeLoaded()
+
+        return try await withCheckedThrowingContinuation { continuation in
+            let id = UUID().uuidString
+            pendingRequests[id] = continuation
+
+            let bodyString = body.flatMap { $0.base64EncodedString() }
+            let request = Request(id: id, method: method, path: path, body: bodyString, accessToken: accessToken)
+
+            guard let payload = try? JSONEncoder().encode(request) else {
+                continuation.resume(throwing: ProxyError.invalidResponse)
+                return
+            }
+
+            let base64 = payload.base64EncodedString()
+            let script = "window.spotifyBridge.performEncodedRequest('" + base64 + "')"
+            webView.evaluateJavaScript(script) { _, error in
+                if let error {
+                    let continuation = self.pendingRequests.removeValue(forKey: id)
+                    continuation?.resume(throwing: error)
+                }
+            }
+        }
+    }
+}
+
+extension SpotifyProxyClient: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        isBridgeReady = true
+        bridgeContinuation?.resume()
+        bridgeContinuation = nil
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        bridgeContinuation?.resume(throwing: error)
+        bridgeContinuation = nil
+    }
+}
+
+extension SpotifyProxyClient: WKScriptMessageHandler {
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        guard message.name == "spotifyProxy" else { return }
+        guard let dataString = message.body as? String, let data = Data(base64Encoded: dataString) else {
+            return
+        }
+
+        guard let response = try? JSONDecoder().decode(Response.self, from: data) else {
+            return
+        }
+
+        guard let continuation = pendingRequests.removeValue(forKey: response.id) else { return }
+
+        if let error = response.error {
+            continuation.resume(throwing: ProxyError.requestFailed(status: response.status, body: error))
+            return
+        }
+
+        if !(200..<300).contains(response.status) {
+            continuation.resume(throwing: ProxyError.requestFailed(status: response.status, body: response.body))
+            return
+        }
+
+        if let body = response.body, let decoded = Data(base64Encoded: body) {
+            continuation.resume(returning: decoded)
+        } else {
+            continuation.resume(returning: Data())
+        }
+    }
+}

--- a/ios/HubitatDashboard/HubitatDashboard/Services/Spotify/SpotifyService.swift
+++ b/ios/HubitatDashboard/HubitatDashboard/Services/Spotify/SpotifyService.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+@MainActor
+final class SpotifyService {
+    enum SpotifyError: Error {
+        case notAuthenticated
+        case invalidResponse
+    }
+
+    private let authManager: SpotifyAuthManager
+    private let proxyClient: SpotifyProxyClient
+    private let decoder = JSONDecoder()
+
+    var isAuthorized: Bool {
+        authManager.isAuthorized
+    }
+
+    init(configuration: AppConfiguration) {
+        self.authManager = SpotifyAuthManager(configuration: configuration)
+        self.proxyClient = SpotifyProxyClient(configuration: configuration)
+    }
+
+    @discardableResult
+    func authorize() async throws -> Bool {
+        _ = try await authManager.authorize()
+        return true
+    }
+
+    func logout() async {
+        authManager.logout()
+    }
+
+    func currentPlayback() async throws -> SpotifyPlaybackState {
+        let data = try await request(method: "GET", path: "/v1/me/player")
+        return try parsePlaybackState(from: data)
+    }
+
+    func play() async throws {
+        _ = try await request(method: "PUT", path: "/v1/me/player/play")
+    }
+
+    func pause() async throws {
+        _ = try await request(method: "PUT", path: "/v1/me/player/pause")
+    }
+
+    func next() async throws {
+        _ = try await request(method: "POST", path: "/v1/me/player/next")
+    }
+
+    func previous() async throws {
+        _ = try await request(method: "POST", path: "/v1/me/player/previous")
+    }
+
+    func setVolume(_ percent: Int) async throws {
+        let path = "/v1/me/player/volume?volume_percent=\(percent)"
+        _ = try await request(method: "PUT", path: path)
+    }
+
+    private func request(method: String, path: String, body: Data? = nil) async throws -> Data {
+        guard let token = authManager.currentToken else {
+            throw SpotifyError.notAuthenticated
+        }
+        return try await proxyClient.perform(method: method, path: path, body: body, accessToken: token.accessToken)
+    }
+
+    private func parsePlaybackState(from data: Data) throws -> SpotifyPlaybackState {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw SpotifyError.invalidResponse
+        }
+
+        guard let item = json["item"] as? [String: Any],
+              let name = item["name"] as? String,
+              let artists = item["artists"] as? [[String: Any]],
+              let album = item["album"] as? [String: Any],
+              let albumName = album["name"] as? String,
+              let uri = item["uri"] as? String else {
+            throw SpotifyError.invalidResponse
+        }
+
+        let artworkURL: URL?
+        if let images = album["images"] as? [[String: Any]], let first = images.first, let url = first["url"] as? String {
+            artworkURL = URL(string: url)
+        } else {
+            artworkURL = nil
+        }
+
+        let artistNames = artists.compactMap { $0["name"] as? String }.joined(separator: ", ")
+        let isPlaying = json["is_playing"] as? Bool ?? false
+        let progress = (json["progress_ms"] as? TimeInterval ?? 0) / 1000
+        let duration = (item["duration_ms"] as? TimeInterval ?? 0) / 1000
+        let device = json["device"] as? [String: Any]
+        let volumePercent = (device?["volume_percent"] as? Double ?? 50) / 100
+
+        return SpotifyPlaybackState(
+            isPlaying: isPlaying,
+            progress: progress,
+            duration: duration,
+            track: SpotifyPlaybackState.Track(
+                uri: uri,
+                name: name,
+                artist: artistNames,
+                album: albumName,
+                artworkURL: artworkURL
+            ),
+            volume: volumePercent
+        )
+    }
+}

--- a/ios/HubitatDashboard/HubitatDashboard/Services/WebSocketClient.swift
+++ b/ios/HubitatDashboard/HubitatDashboard/Services/WebSocketClient.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+final class WebSocketClient: NSObject {
+    enum State {
+        case connecting
+        case connected
+        case disconnected
+    }
+
+    enum Message {
+        case hubitat(DeviceState)
+        case spotify(SpotifyPlaybackState)
+        case notification(String)
+    }
+
+    private let url: URL
+    private var task: URLSessionWebSocketTask?
+    private lazy var session: URLSession = {
+        let configuration = URLSessionConfiguration.default
+        return URLSession(configuration: configuration, delegate: self, delegateQueue: .main)
+    }()
+
+    var onMessage: ((Message) -> Void)?
+    var onStateChange: ((State) -> Void)?
+
+    init(url: URL) {
+        self.url = url
+        super.init()
+    }
+
+    func connect() {
+        disconnect()
+        onStateChange?(.connecting)
+        task = session.webSocketTask(with: url)
+        task?.resume()
+        receive()
+    }
+
+    func disconnect() {
+        task?.cancel(with: .normalClosure, reason: nil)
+        task = nil
+        onStateChange?(.disconnected)
+    }
+
+    private func receive() {
+        task?.receive { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success(let message):
+                self.handle(message)
+                self.receive()
+            case .failure:
+                self.disconnect()
+            }
+        }
+    }
+
+    private func handle(_ message: URLSessionWebSocketTask.Message) {
+        switch message {
+        case .string(let string):
+            guard let data = string.data(using: .utf8) else { return }
+            parse(data: data)
+        case .data(let data):
+            parse(data: data)
+        @unknown default:
+            break
+        }
+    }
+
+    private func parse(data: Data) {
+        guard
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let type = json["type"] as? String
+        else { return }
+
+        switch type {
+        case "hubitat_state":
+            if let device = try? JSONDecoder().decode(DeviceState.self, from: data) {
+                onMessage?(.hubitat(device))
+            }
+        case "spotify_state":
+            if let payload = json["payload"],
+               let payloadData = try? JSONSerialization.data(withJSONObject: payload, options: []),
+               let state = try? JSONDecoder().decode(SpotifyPlaybackState.self, from: payloadData) {
+                onMessage?(.spotify(state))
+            }
+        case "notification":
+            if let message = json["note"] as? String {
+                onMessage?(.notification(message))
+            }
+        default:
+            break
+        }
+    }
+}
+
+extension WebSocketClient: URLSessionWebSocketDelegate {
+    func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {
+        onStateChange?(.connected)
+    }
+
+    func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        onStateChange?(.disconnected)
+    }
+}

--- a/ios/HubitatDashboard/HubitatDashboard/Services/WebSocketClient.swift
+++ b/ios/HubitatDashboard/HubitatDashboard/Services/WebSocketClient.swift
@@ -9,6 +9,7 @@ final class WebSocketClient: NSObject {
 
     enum Message {
         case hubitat(DeviceState)
+        case hubitatAttributes(deviceId: String, label: String?, attributes: [String: DeviceState.AttributeValue])
         case spotify(SpotifyPlaybackState)
         case notification(String)
     }
@@ -78,19 +79,126 @@ final class WebSocketClient: NSObject {
             if let device = try? JSONDecoder().decode(DeviceState.self, from: data) {
                 onMessage?(.hubitat(device))
             }
+        case "device_state_update":
+            guard let deviceId = json["deviceId"] as? String else { return }
+            let label = json["label"] as? String
+            let attributes = (json["attributes"] as? [String: Any]).map(parseAttributes) ?? [:]
+            if !attributes.isEmpty || label != nil {
+                onMessage?(.hubitatAttributes(deviceId: deviceId, label: label, attributes: attributes))
+            }
         case "spotify_state":
             if let payload = json["payload"],
                let payloadData = try? JSONSerialization.data(withJSONObject: payload, options: []),
                let state = try? JSONDecoder().decode(SpotifyPlaybackState.self, from: payloadData) {
                 onMessage?(.spotify(state))
             }
+        case "spotify_state_change":
+            if let payload = json["data"] as? [String: Any], let state = parseSpotifyStateChange(payload) {
+                onMessage?(.spotify(state))
+            }
+        case "device_notification", "general_notification", "lrgroup_update", "reolink_webhook":
+            if let payload = json["payload"] {
+                if let message = extractNotificationMessage(from: payload) {
+                    onMessage?(.notification(message))
+                }
+            }
         case "notification":
             if let message = json["note"] as? String {
                 onMessage?(.notification(message))
             }
+        case "device_refresh_request":
+            if let deviceId = json["deviceId"] as? String {
+                onMessage?(.notification("Refresh requested for device #\(deviceId)"))
+            }
+        case "bulk_device_refresh_request":
+            if let deviceIds = json["deviceIds"] as? [String] {
+                onMessage?(.notification("Refresh requested for \(deviceIds.count) devices"))
+            }
         default:
             break
         }
+    }
+
+    private func parseAttributes(_ attributes: [String: Any]) -> [String: DeviceState.AttributeValue] {
+        attributes.reduce(into: [:]) { result, entry in
+            guard let valueString = stringify(value: entry.value) else { return }
+            result[entry.key] = DeviceState.AttributeValue(name: entry.key, value: valueString)
+        }
+    }
+
+    private func parseSpotifyStateChange(_ data: [String: Any]) -> SpotifyPlaybackState? {
+        guard let trackInfo = data["trackInfo"] as? [String: Any],
+              let name = trackInfo["name"] as? String,
+              let artist = trackInfo["artist"] as? String,
+              let album = trackInfo["album"] as? String else {
+            return nil
+        }
+
+        let isPlaying = data["isPlaying"] as? Bool ?? false
+        let durationSeconds = ((trackInfo["duration"] as? TimeInterval) ?? 0) / 1000
+        let progressSeconds = ((trackInfo["position"] as? TimeInterval) ?? 0) / 1000
+        let imageURLString = trackInfo["imageUrl"] as? String
+        let artworkURL = imageURLString.flatMap(URL.init(string:))
+        let trackID = trackInfo["id"] as? String
+        let explicitURI = trackInfo["uri"] as? String
+        let uri = explicitURI ?? (trackID.map { "spotify:track:\($0)" } ?? name)
+
+        let deviceInfo = data["device"] as? [String: Any]
+        let volumePercent = (deviceInfo?["volume"] as? Double) ?? (deviceInfo?["volume"] as? NSNumber)?.doubleValue ?? 0
+        let normalizedVolume = max(0, min(1, volumePercent / 100))
+
+        return SpotifyPlaybackState(
+            isPlaying: isPlaying,
+            progress: progressSeconds,
+            duration: durationSeconds,
+            track: SpotifyPlaybackState.Track(
+                uri: uri,
+                name: name,
+                artist: artist,
+                album: album,
+                artworkURL: artworkURL
+            ),
+            volume: normalizedVolume
+        )
+    }
+
+    private func extractNotificationMessage(from payload: Any) -> String? {
+        if let dictionary = payload as? [String: Any] {
+            if let message = dictionary["message"] as? String { return message }
+            if let description = dictionary["description"] as? String { return description }
+            if let note = dictionary["note"] as? String { return note }
+            if JSONSerialization.isValidJSONObject(dictionary),
+               let data = try? JSONSerialization.data(withJSONObject: dictionary, options: [.sortedKeys]),
+               let string = String(data: data, encoding: .utf8) {
+                return string
+            }
+        } else if let array = payload as? [Any] {
+            if JSONSerialization.isValidJSONObject(array),
+               let data = try? JSONSerialization.data(withJSONObject: array, options: []),
+               let string = String(data: data, encoding: .utf8) {
+                return string
+            }
+        } else if let string = payload as? String {
+            return string
+        }
+
+        return stringify(value: payload)
+    }
+
+    private func stringify(value: Any) -> String? {
+        if let string = value as? String {
+            return string
+        }
+        if let number = value as? NSNumber {
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                return number.boolValue ? "true" : "false"
+            }
+            return number.stringValue
+        }
+        if value is NSNull {
+            return nil
+        }
+        return String(describing: value)
     }
 }
 

--- a/ios/HubitatDashboard/HubitatDashboard/Support/AppConfiguration.example.plist
+++ b/ios/HubitatDashboard/HubitatDashboard/Support/AppConfiguration.example.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>BackendBaseURL</key>
+    <string>https://192.168.1.10:4711</string>
+    <key>WebSocketURL</key>
+    <string>wss://192.168.1.10:4712</string>
+    <key>GithubProxyBaseURL</key>
+    <string>https://your-github-username.github.io/spotify-proxy</string>
+    <key>SpotifyClientID</key>
+    <string>your-client-id</string>
+    <key>SpotifyRedirectScheme</key>
+    <string>hubitatdashboard</string>
+</dict>
+</plist>

--- a/ios/HubitatDashboard/HubitatDashboard/Support/Info.plist
+++ b/ios/HubitatDashboard/HubitatDashboard/Support/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>HubitatDashboard</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.hubitatdashboard</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>UILaunchStoryboardName</key>
+    <string></string>
+    <key>UIRequiredDeviceCapabilities</key>
+    <array>
+        <string>armv7</string>
+    </array>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+</dict>
+</plist>

--- a/ios/HubitatDashboard/HubitatDashboard/ViewModels/DashboardViewModel.swift
+++ b/ios/HubitatDashboard/HubitatDashboard/ViewModels/DashboardViewModel.swift
@@ -153,6 +153,19 @@ final class DashboardViewModel: ObservableObject {
             } else {
                 devices.append(device)
             }
+        case .hubitatAttributes(let deviceId, let label, let attributes):
+            if let index = devices.firstIndex(where: { $0.deviceId == deviceId }) {
+                var current = devices[index]
+                var updatedAttributes = current.attributes
+                for (key, value) in attributes {
+                    updatedAttributes[key] = value
+                }
+                let updatedLabel = label?.isEmpty == false ? label! : current.label
+                devices[index] = DeviceState(deviceId: current.deviceId, label: updatedLabel, attributes: updatedAttributes)
+            } else {
+                let resolvedLabel = label?.isEmpty == false ? label! : "Device #\(deviceId)"
+                devices.append(DeviceState(deviceId: deviceId, label: resolvedLabel, attributes: attributes))
+            }
         case .spotify(let state):
             spotifyState = state
         case .notification(let note):

--- a/ios/HubitatDashboard/HubitatDashboard/ViewModels/DashboardViewModel.swift
+++ b/ios/HubitatDashboard/HubitatDashboard/ViewModels/DashboardViewModel.swift
@@ -1,0 +1,176 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class DashboardViewModel: ObservableObject {
+    @Published private(set) var devices: [DeviceState] = []
+    @Published private(set) var spotifyState: SpotifyPlaybackState?
+    @Published private(set) var connectionStatus: ConnectionStatus = .disconnected
+    @Published private(set) var spotifyIsAuthenticated = false
+    @Published private(set) var errorMessage: String?
+
+    private var hubitatService: HubitatService?
+    private var webSocketClient: WebSocketClient?
+    private var spotifyService: SpotifyService?
+
+    private var configuration: AppConfiguration?
+    private var didBootstrap = false
+
+    init(preview: Bool = false) {
+        if preview {
+            self.devices = DeviceState.previewDevices
+            self.spotifyState = .preview
+            self.connectionStatus = .connected
+            self.spotifyIsAuthenticated = true
+        }
+    }
+
+    func bootstrapIfNeeded(configuration: AppConfiguration) async {
+        guard !didBootstrap else { return }
+        self.configuration = configuration
+
+        let hubitatService = HubitatService(baseURL: configuration.backendBaseURL)
+        let webSocketClient = WebSocketClient(url: configuration.webSocketURL)
+        let spotifyService = SpotifyService(configuration: configuration)
+
+        self.hubitatService = hubitatService
+        self.webSocketClient = webSocketClient
+        self.spotifyService = spotifyService
+
+        webSocketClient.onMessage = { [weak self] message in
+            Task { await self?.handleWebSocketMessage(message) }
+        }
+
+        webSocketClient.onStateChange = { [weak self] state in
+            Task { await self?.handleWebSocketStateChange(state) }
+        }
+
+        await refreshDevices()
+        webSocketClient.connect()
+        await updateSpotifyState()
+        didBootstrap = true
+    }
+
+    func reconnectWebSocket() {
+        webSocketClient?.disconnect()
+        webSocketClient?.connect()
+    }
+
+    func refreshDevices() async {
+        guard let hubitatService else { return }
+        do {
+            devices = try await hubitatService.fetchDevices()
+        } catch {
+            errorMessage = "Failed to load devices: \(error.localizedDescription)"
+        }
+    }
+
+    func authenticateSpotify(from configuration: AppConfiguration) async {
+        guard let spotifyService else { return }
+        do {
+            spotifyIsAuthenticated = try await spotifyService.authorize()
+            if spotifyIsAuthenticated {
+                await updateSpotifyState()
+            }
+        } catch {
+            errorMessage = "Spotify authentication failed: \(error.localizedDescription)"
+        }
+    }
+
+    func logoutSpotify() async {
+        await spotifyService?.logout()
+        spotifyState = nil
+        spotifyIsAuthenticated = false
+    }
+
+    func playPause() async {
+        guard let spotifyService else { return }
+        do {
+            if spotifyState?.isPlaying == true {
+                try await spotifyService.pause()
+            } else {
+                try await spotifyService.play()
+            }
+            await updateSpotifyState()
+        } catch {
+            errorMessage = "Playback failed: \(error.localizedDescription)"
+        }
+    }
+
+    func skipNext() async {
+        guard let spotifyService else { return }
+        do {
+            try await spotifyService.next()
+            await updateSpotifyState()
+        } catch {
+            errorMessage = "Unable to skip: \(error.localizedDescription)"
+        }
+    }
+
+    func skipPrevious() async {
+        guard let spotifyService else { return }
+        do {
+            try await spotifyService.previous()
+            await updateSpotifyState()
+        } catch {
+            errorMessage = "Unable to skip: \(error.localizedDescription)"
+        }
+    }
+
+    func setVolume(to value: Double) async {
+        guard let spotifyService else { return }
+        do {
+            try await spotifyService.setVolume(Int(value * 100))
+            await updateSpotifyState()
+        } catch {
+            errorMessage = "Unable to set volume: \(error.localizedDescription)"
+        }
+    }
+
+    private func updateSpotifyState() async {
+        guard let spotifyService else { return }
+        do {
+            spotifyState = try await spotifyService.currentPlayback()
+            spotifyIsAuthenticated = spotifyService.isAuthorized
+        } catch {
+            if (error as? SpotifyService.SpotifyError) == .notAuthenticated {
+                spotifyIsAuthenticated = false
+            } else {
+                errorMessage = "Unable to load playback state: \(error.localizedDescription)"
+            }
+        }
+    }
+
+    private func handleWebSocketStateChange(_ state: WebSocketClient.State) async {
+        connectionStatus = ConnectionStatus(state: state)
+    }
+
+    private func handleWebSocketMessage(_ message: WebSocketClient.Message) async {
+        switch message {
+        case .hubitat(let device):
+            if let index = devices.firstIndex(where: { $0.deviceId == device.deviceId }) {
+                devices[index] = device
+            } else {
+                devices.append(device)
+            }
+        case .spotify(let state):
+            spotifyState = state
+        case .notification(let note):
+            errorMessage = note
+        }
+    }
+
+    enum ConnectionStatus: String {
+        case connecting
+        case connected
+        case disconnected
+
+        init(state: WebSocketClient.State) {
+            switch state {
+            case .connecting: self = .connecting
+            case .connected: self = .connected
+            case .disconnected: self = .disconnected
+            }
+        }
+    }
+}

--- a/ios/HubitatDashboard/HubitatDashboard/Views/DashboardView.swift
+++ b/ios/HubitatDashboard/HubitatDashboard/Views/DashboardView.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+struct DashboardView: View {
+    @EnvironmentObject private var viewModel: DashboardViewModel
+
+    var body: some View {
+        List {
+            Section(header: statusHeader) {
+                ForEach(viewModel.devices) { device in
+                    NavigationLink(destination: DeviceDetailView(device: device)) {
+                        DeviceRow(device: device)
+                    }
+                }
+            }
+
+            if let spotifyState = viewModel.spotifyState {
+                Section("Spotify") {
+                    SpotifyPlayerView(state: spotifyState)
+                        .environmentObject(viewModel)
+                }
+            } else {
+                Section("Spotify") {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Not signed in")
+                            .font(.headline)
+                        Text("Use the toolbar to authenticate with Spotify.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 8)
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .alert(item: $viewModel.errorMessage.map(IdentifiedError.init)) { error in
+            Alert(title: Text("Error"), message: Text(error.message), dismissButton: .default(Text("OK")))
+        }
+    }
+
+    private var statusHeader: some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(statusColor)
+                .frame(width: 12, height: 12)
+            Text("Realtime updates: \(viewModel.connectionStatus.rawValue.capitalized)")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var statusColor: Color {
+        switch viewModel.connectionStatus {
+        case .connected: return .green
+        case .connecting: return .yellow
+        case .disconnected: return .red
+        }
+    }
+}
+
+private struct IdentifiedError: Identifiable {
+    let id = UUID()
+    let message: String
+}
+
+struct DashboardView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationStack {
+            DashboardView()
+                .environmentObject(DashboardViewModel(preview: true))
+        }
+    }
+}

--- a/ios/HubitatDashboard/HubitatDashboard/Views/DeviceDetailView.swift
+++ b/ios/HubitatDashboard/HubitatDashboard/Views/DeviceDetailView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct DeviceDetailView: View {
+    let device: DeviceState
+
+    var body: some View {
+        List {
+            Section(header: Text(device.label)) {
+                ForEach(Array(device.attributes.sorted(by: { $0.key < $1.key })), id: \.0) { key, value in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(key.capitalized)
+                            .font(.headline)
+                        Text(value.value)
+                            .font(.body)
+                        if let unit = value.unit {
+                            Text(unit)
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
+                        if let updated = value.lastUpdated {
+                            Text("Updated \(updated.formatted(.relative(presentation: .named)))")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+        }
+        .navigationTitle(device.label)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+struct DeviceDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationStack {
+            DeviceDetailView(device: DeviceState.previewDevices.first!)
+        }
+    }
+}

--- a/ios/HubitatDashboard/HubitatDashboard/Views/DeviceRow.swift
+++ b/ios/HubitatDashboard/HubitatDashboard/Views/DeviceRow.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct DeviceRow: View {
+    let device: DeviceState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(device.label)
+                .font(.headline)
+            HStack(spacing: 12) {
+                ForEach(Array(device.attributes.sorted(by: { $0.key < $1.key })), id: \.0) { key, value in
+                    VStack(alignment: .leading) {
+                        Text(key.capitalized)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text(value.value)
+                            .font(.subheadline)
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 6)
+    }
+}
+
+struct DeviceRow_Previews: PreviewProvider {
+    static var previews: some View {
+        List {
+            DeviceRow(device: DeviceState.previewDevices.first!)
+        }
+    }
+}

--- a/ios/HubitatDashboard/HubitatDashboard/Views/SpotifyPlayerView.swift
+++ b/ios/HubitatDashboard/HubitatDashboard/Views/SpotifyPlayerView.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+
+struct SpotifyPlayerView: View {
+    @EnvironmentObject private var viewModel: DashboardViewModel
+    let state: SpotifyPlaybackState
+    @State private var volume: Double
+
+    init(state: SpotifyPlaybackState) {
+        self.state = state
+        self._volume = State(initialValue: state.volume)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 12) {
+                AsyncImage(url: state.track.artworkURL) { phase in
+                    switch phase {
+                    case .empty:
+                        ProgressView()
+                    case .success(let image):
+                        image
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                    case .failure:
+                        Color.secondary
+                    @unknown default:
+                        Color.secondary
+                    }
+                }
+                .frame(width: 80, height: 80)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(state.track.name)
+                        .font(.headline)
+                    Text(state.track.artist)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Text(state.track.album)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            ProgressView(value: state.progress / max(state.duration, 1))
+            HStack {
+                Text(format(time: state.progress))
+                    .font(.footnote)
+                Spacer()
+                Text(format(time: state.duration))
+                    .font(.footnote)
+            }
+            .foregroundStyle(.secondary)
+
+            HStack(spacing: 24) {
+                Button(action: { Task { await viewModel.skipPrevious() } }) {
+                    Image(systemName: "backward.fill")
+                        .font(.title2)
+                }
+                Button(action: { Task { await viewModel.playPause() } }) {
+                    Image(systemName: state.isPlaying ? "pause.circle.fill" : "play.circle.fill")
+                        .font(.largeTitle)
+                }
+                Button(action: { Task { await viewModel.skipNext() } }) {
+                    Image(systemName: "forward.fill")
+                        .font(.title2)
+                }
+            }
+            .buttonStyle(.plain)
+            .frame(maxWidth: .infinity)
+
+            VStack(alignment: .leading) {
+                Text("Volume")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Slider(value: $volume, in: 0...1, onEditingChanged: { editing in
+                    guard !editing else { return }
+                    Task { await viewModel.setVolume(to: volume) }
+                })
+            }
+        }
+        .padding(.vertical, 8)
+        .onChange(of: state.volume) { _, newValue in
+            volume = newValue
+        }
+    }
+
+    private func format(time: TimeInterval) -> String {
+        let minutes = Int(time) / 60
+        let seconds = Int(time) % 60
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+}
+
+struct SpotifyPlayerView_Previews: PreviewProvider {
+    static var previews: some View {
+        SpotifyPlayerView(state: .preview)
+            .environmentObject(DashboardViewModel(preview: true))
+    }
+}

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,51 @@
+# HubitatDashboard iOS Conversion
+
+This directory contains a native SwiftUI implementation of the Hubitat dashboard along with configuration required to bridge Spotify authentication through GitHub Pages.
+
+## Structure
+
+```
+ios/
+  HubitatDashboard/
+    HubitatDashboardApp.swift       # App entry point
+    Core/                           # Runtime configuration helpers
+    Models/                         # Codable view models for Hubitat + Spotify
+    Services/                       # Networking, WebSocket, and Spotify bridge clients
+    Views/                          # SwiftUI interface for devices and Spotify player
+    Support/AppConfiguration.example.plist
+    Resources/                      # Assets placeholder for Xcode
+    HubitatDashboard.xcodeproj/     # Xcode project for the iOS app
+  README.md
+```
+
+## Configuration
+
+1. Duplicate `Support/AppConfiguration.example.plist` and rename it to `AppConfiguration.plist`.
+2. Update the keys to match your environment:
+   - `BackendBaseURL`: HTTPS URL of the Node.js backend defined in `main.js`.
+   - `WebSocketURL`: WebSocket endpoint for `wss://<host>:4712`.
+   - `GithubProxyBaseURL`: The GitHub Pages URL that serves the Spotify proxy bridge (see below).
+   - `SpotifyClientID`: Client ID from your Spotify developer application configured for the implicit grant flow.
+   - `SpotifyRedirectScheme`: Custom URL scheme registered in Xcode (default `hubitatdashboard`).
+
+## GitHub Pages Spotify Bridge
+
+The iOS app expects an HTTPS hosted bridge that lives at `GithubProxyBaseURL`. The HTML and JavaScript assets for that proxy are located in `docs/spotify-proxy`. Deploy that directory to GitHub Pages (for example via the `docs/` folder convention).
+
+The bridge performs two tasks:
+
+1. **OAuth Redirect Handling** – orchestrates the implicit grant flow and returns the access token to the iOS app via a custom URL scheme.
+2. **API Forwarding** – exposes a messaging bridge that accepts encoded requests from the app and executes Spotify Web API calls inside the GitHub Pages context.
+
+## Building the App
+
+1. Open `ios/HubitatDashboard/HubitatDashboard.xcodeproj` in Xcode 15 or newer.
+2. Ensure your development team is selected under Signing & Capabilities.
+3. Add the custom URL scheme (`hubitatdashboard`) to the project if you change it in the configuration plist.
+4. Build and run on a simulator or device.
+
+## Runtime Notes
+
+- The app uses the existing WebSocket stream from the Electron backend for real-time Hubitat updates.
+- Spotify playback controls are routed through the GitHub Pages proxy. Because the implicit grant flow does not support refresh tokens, the user may need to re-authenticate once the access token expires.
+- Sensitive secrets should never be committed. Keep `AppConfiguration.plist` out of version control or manage via Xcode configurations.

--- a/ios/README.md
+++ b/ios/README.md
@@ -44,6 +44,31 @@ The bridge performs two tasks:
 3. Add the custom URL scheme (`hubitatdashboard`) to the project if you change it in the configuration plist.
 4. Build and run on a simulator or device.
 
+## Installing on a Physical iPhone
+
+Follow these steps to install the app directly onto an iPhone that you own:
+
+1. **Join the Apple Developer Program (optional).**
+   - A paid Developer Program membership is required to distribute the app via TestFlight or the App Store, but is not required for personal deployment to your own device.
+2. **Connect your iPhone to your Mac** with a USB cable (or configure wireless debugging in Xcode).
+3. **Trust the computer** on the device when prompted.
+4. In Xcode, **select your iPhone** from the device selector near the Run button.
+5. Under the project target's **Signing & Capabilities** tab:
+   - Choose your personal development team.
+   - Ensure the Bundle Identifier is unique (e.g., append your initials).
+6. **Update the provisioning profile** by letting Xcode manage signing. If prompted, sign in with your Apple ID and allow Xcode to create a provisioning profile.
+7. **Build & Run** (`Cmd + R`). Xcode will compile the project, install it on the connected iPhone, and launch it automatically.
+8. On first launch you may be prompted to **trust the developer profile** on the device:
+   - Go to *Settings → General → VPN & Device Management*.
+   - Tap your Apple ID under Developer App and select *Trust*.
+9. The app is now available on your home screen. Subsequent builds can be installed by pressing Run again in Xcode.
+
+### Handling Spotify Redirects on Device
+
+- Ensure the `SpotifyRedirectScheme` in `AppConfiguration.plist` matches the URL scheme registered in Xcode (*Info → URL Types*).
+- Verify that the GitHub Pages proxy is accessible over HTTPS from the device's network.
+- When prompted during the OAuth flow, Safari will redirect back into the app using the configured scheme.
+
 ## Runtime Notes
 
 - The app uses the existing WebSocket stream from the Electron backend for real-time Hubitat updates.


### PR DESCRIPTION
## Summary
- add a native SwiftUI iOS application that mirrors the Hubitat dashboard, Spotify controls, and WebSocket updates
- introduce a GitHub Pages hosted Spotify proxy that drives OAuth and forwards API requests for the mobile client
- document iOS configuration, assets, and proxy deployment details

## Testing
- Not run (iOS project requires Xcode)

------
https://chatgpt.com/codex/tasks/task_e_6902d43027d48331adc4486466a0fd06